### PR TITLE
Add codex agent plugin for OpenAI Codex CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,35 @@ agent:
 | `{{payload}}` | ペイロード全体 (JSON) |
 | `{{payload.key}}` | ペイロード内の特定キー |
 
+### agent:codex
+
+OpenAI Codex CLI を使用してタスクを実行します。
+
+```yaml
+agent:
+  plugin: "codex"
+  config:
+    prompt_template: |
+      以下の内容を分析してください:
+      {{payload}}
+    workdir: "/path/to/workdir"
+    timeout: 300
+    model: "o4-mini"
+    approval_mode: "suggest"
+```
+
+**設定パラメータ:**
+
+| パラメータ | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `prompt_template` | string | `{{payload}}` | プロンプトテンプレート |
+| `workdir` | string | - | 作業ディレクトリ |
+| `timeout` | number | `300` | タイムアウト (秒) |
+| `model` | string | - | モデル名 (例: `o4-mini`, `gpt-4.1`) |
+| `approval_mode` | string | - | `suggest`, `auto-edit`, `full-auto` |
+
+**注意:** Codex CLI は別途インストールが必要です: `npm i -g @openai/codex`
+
 ## 開発
 
 ```bash

--- a/src/plugins/agents/codex.ts
+++ b/src/plugins/agents/codex.ts
@@ -1,0 +1,84 @@
+import { execFile } from "node:child_process";
+import { ulid } from "ulid";
+import type { AgentPlugin } from "../protocol.js";
+import type { AgentResult, EvOrchEvent } from "../../core/types.js";
+
+export class CodexAgent implements AgentPlugin {
+  async run(
+    config: Record<string, unknown>,
+    event: EvOrchEvent,
+  ): Promise<AgentResult> {
+    const template = (config.prompt_template as string) ?? "{{payload}}";
+    const timeout = ((config.timeout as number | undefined) ?? 300) * 1000;
+    const workdir = config.workdir as string | undefined;
+    const model = config.model as string | undefined;
+    const approvalMode = config.approval_mode as string | undefined;
+
+    // テンプレート変数を展開
+    const prompt = this.expandTemplate(template, event);
+
+    // codex コマンドを構築
+    const args = ["-q"]; // quiet mode (非対話)
+    if (model) {
+      args.push("-m", model);
+    }
+    if (approvalMode) {
+      args.push("-a", approvalMode);
+    }
+    args.push(prompt);
+
+    const startedAt = new Date().toISOString();
+    const startTime = Date.now();
+
+    return new Promise<AgentResult>((resolve) => {
+      const child = execFile("codex", args, {
+        timeout,
+        maxBuffer: 10 * 1024 * 1024,
+        cwd: workdir,
+      }, (error, stdout, stderr) => {
+        const completedAt = new Date().toISOString();
+        const duration_ms = Date.now() - startTime;
+
+        if (error) {
+          const isTimeout = error.killed || error.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+          resolve({
+            result_id: ulid(),
+            event_id: event.event_id,
+            policy_name: "",
+            agent_plugin: "codex",
+            status: isTimeout ? "timeout" : "failure",
+            output: stderr || stdout || String(error),
+            duration_ms,
+            started_at: startedAt,
+            completed_at: completedAt,
+          });
+          return;
+        }
+
+        resolve({
+          result_id: ulid(),
+          event_id: event.event_id,
+          policy_name: "",
+          agent_plugin: "codex",
+          status: "success",
+          output: stdout,
+          duration_ms,
+          started_at: startedAt,
+          completed_at: completedAt,
+        });
+      });
+    });
+  }
+
+  private expandTemplate(template: string, event: EvOrchEvent): string {
+    return template
+      .replace(/\{\{event_id\}\}/g, event.event_id)
+      .replace(/\{\{event_type\}\}/g, event.type)
+      .replace(/\{\{source\}\}/g, event.source)
+      .replace(/\{\{payload\}\}/g, JSON.stringify(event.payload, null, 2))
+      .replace(/\{\{payload\.(\w+)\}\}/g, (_, key) => {
+        const value = event.payload[key];
+        return typeof value === "string" ? value : JSON.stringify(value);
+      });
+  }
+}

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -3,6 +3,7 @@ import type { JudgeResult, AgentResult, EvOrchEvent } from "../core/types.js";
 import { ShellJudge } from "./judges/shell.js";
 import { ClaudeCodeAgent } from "./agents/claude-code.js";
 import { ShellAgent } from "./agents/shell.js";
+import { CodexAgent } from "./agents/codex.js";
 
 const BUILTIN_JUDGES: Record<string, () => JudgePlugin> = {
   shell: () => new ShellJudge(),
@@ -11,6 +12,7 @@ const BUILTIN_JUDGES: Record<string, () => JudgePlugin> = {
 const BUILTIN_AGENTS: Record<string, () => AgentPlugin> = {
   "claude-code": () => new ClaudeCodeAgent(),
   shell: () => new ShellAgent(),
+  codex: () => new CodexAgent(),
 };
 
 export class PluginRuntime {

--- a/test/plugins/codex-agent.test.ts
+++ b/test/plugins/codex-agent.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { CodexAgent } from "../../src/plugins/agents/codex.js";
+import type { EvOrchEvent } from "../../src/core/types.js";
+
+const agent = new CodexAgent();
+
+const createEvent = (payload: Record<string, unknown>): EvOrchEvent => ({
+  event_id: "test-event-001",
+  source: "test-job",
+  type: "test_event",
+  severity: "medium",
+  fingerprint: "test:001",
+  payload,
+  labels: {},
+  created_at: new Date().toISOString(),
+  run_id: "run-001",
+});
+
+describe("CodexAgent", () => {
+  it("テンプレート変数 {{event_type}} を展開する", () => {
+    const event = createEvent({});
+    // @ts-expect-error - private method test
+    const result = agent.expandTemplate("Type: {{event_type}}", event);
+    expect(result).toBe("Type: test_event");
+  });
+
+  it("テンプレート変数 {{source}} を展開する", () => {
+    const event = createEvent({});
+    // @ts-expect-error - private method test
+    const result = agent.expandTemplate("Source: {{source}}", event);
+    expect(result).toBe("Source: test-job");
+  });
+
+  it("テンプレート変数 {{event_id}} を展開する", () => {
+    const event = createEvent({});
+    // @ts-expect-error - private method test
+    const result = agent.expandTemplate("ID: {{event_id}}", event);
+    expect(result).toBe("ID: test-event-001");
+  });
+
+  it("テンプレート変数 {{payload}} を展開する", () => {
+    const event = createEvent({ count: 3, name: "test" });
+    // @ts-expect-error - private method test
+    const result = agent.expandTemplate("Data: {{payload}}", event);
+    expect(result).toContain('"count": 3');
+    expect(result).toContain('"name": "test"');
+  });
+
+  it("テンプレート変数 {{payload.key}} を展開する", () => {
+    const event = createEvent({ message: "hello world" });
+    // @ts-expect-error - private method test
+    const result = agent.expandTemplate("Msg: {{payload.message}}", event);
+    expect(result).toBe("Msg: hello world");
+  });
+
+  it("codex コマンドが存在しない場合は failure を返す", async () => {
+    const event = createEvent({ message: "hello" });
+    const result = await agent.run(
+      { prompt_template: "test", timeout: 5 },
+      event,
+    );
+
+    expect(result.status).toBe("failure");
+    expect(result.agent_plugin).toBe("codex");
+  });
+});


### PR DESCRIPTION
## Summary

- OpenAI Codex CLI に対応した agent プラグインを追加
- `codex -q` (quiet mode) を使用して非対話で実行
- テンプレート変数 `{{payload}}`, `{{event_type}}`, `{{source}}`, `{{event_id}}` に対応

## Changes

- `src/plugins/agents/codex.ts` - Codex agent プラグインを追加
- `src/plugins/runtime.ts` - BUILTIN_AGENTS に codex を登録
- `test/plugins/codex-agent.test.ts` - テストを追加
- `README.md` - agent:codex のドキュメントを追加

## Usage

```yaml
policies:
  - name: codex-policy
    match:
      type: some_event
    agent:
      plugin: codex
      config:
        prompt_template: |
          以下の内容を分析してください:
          {{payload}}
        model: o4-mini
        timeout: 300
```

## Test plan

- [x] テンプレート変数の展開テスト
- [x] codex コマンド不在時のエラーハンドリングテスト
- [x] 既存テストが全て通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)