### PR TITLE
Add results command to view agent execution logs

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { registerStatus } from "./status.js";
 import { registerHistory } from "./history.js";
 import { registerValidate } from "./validate.js";
 import { registerJob } from "./job.js";
+import { registerResults } from "./results.js";
 
 export const DEFAULT_CONFIG_DIR = join(homedir(), ".config", "evorch");
 export const DEFAULT_CONFIG_PATH = join(DEFAULT_CONFIG_DIR, "config.yaml");
@@ -28,6 +29,7 @@ export function createCli(): Command {
   registerHistory(program);
   registerValidate(program);
   registerJob(program);
+  registerResults(program);
 
   return program;
 }

--- a/src/cli/results.ts
+++ b/src/cli/results.ts
@@ -1,0 +1,110 @@
+import type { Command } from "commander";
+import { loadConfig } from "../config/loader.js";
+import { openDatabase } from "../store/database.js";
+import { Repository } from "../store/repository.js";
+import type { AgentResult } from "../core/types.js";
+
+const ULID_RE = /^[0-9A-Z]{26}$/;
+
+export function registerResults(program: Command): void {
+  program
+    .command("results [policy-or-id]")
+    .description("エージェント実行結果を表示。RESULT ID を指定すると1件詳細表示")
+    .option("-n, --limit <number>", "表示件数（一覧時）", "20")
+    .option("--output", "出力テキストも表示（一覧時）")
+    .option("--json", "JSON形式で出力")
+    .action(async (arg, opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const config = loadConfig(globalOpts.config);
+      const db = openDatabase(config.store.path);
+      const store = new Repository(db);
+
+      if (arg && ULID_RE.test(arg)) {
+        // 1件詳細表示
+        const result = store.getAgentResultById(arg);
+        if (!result) {
+          console.error(`結果が見つかりません: ${arg}`);
+          process.exit(1);
+        }
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          printDetail(result);
+        }
+      } else {
+        // 一覧表示
+        const limit = parseInt(opts.limit, 10);
+        const results = store.getRecentAgentResults(arg, limit);
+
+        if (opts.json) {
+          console.log(JSON.stringify(results, null, 2));
+        } else {
+          printList(results, opts.output as boolean);
+        }
+      }
+
+      db.close();
+    });
+}
+
+function printList(results: AgentResult[], showOutput: boolean): void {
+  console.log(
+    padEnd("RESULT ID", 28) +
+      padEnd("POLICY", 24) +
+      padEnd("PLUGIN", 16) +
+      padEnd("STATUS", 10) +
+      padEnd("DURATION", 10) +
+      "STARTED",
+  );
+  console.log("-".repeat(106));
+  for (const r of results) {
+    console.log(
+      padEnd(r.result_id, 28) +
+        padEnd(r.policy_name, 24) +
+        padEnd(r.agent_plugin, 16) +
+        padEnd(r.status, 10) +
+        padEnd(`${r.duration_ms}ms`, 10) +
+        formatTime(r.started_at),
+    );
+    if (showOutput && r.output) {
+      console.log();
+      console.log(indent(r.output, "  "));
+      console.log();
+    }
+  }
+}
+
+function printDetail(r: AgentResult): void {
+  console.log(`Result ID  : ${r.result_id}`);
+  console.log(`Event ID   : ${r.event_id}`);
+  console.log(`Policy     : ${r.policy_name}`);
+  console.log(`Plugin     : ${r.agent_plugin}`);
+  console.log(`Status     : ${r.status}`);
+  console.log(`Duration   : ${r.duration_ms}ms`);
+  console.log(`Started    : ${formatTime(r.started_at)}`);
+  console.log(`Completed  : ${formatTime(r.completed_at)}`);
+  if (r.output) {
+    console.log();
+    console.log("--- Output ---");
+    console.log(r.output);
+  }
+}
+
+function padEnd(str: string, len: number): string {
+  return str.length >= len ? str : str + " ".repeat(len - str.length);
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
+  } catch {
+    return iso;
+  }
+}
+
+function indent(text: string, prefix: string): string {
+  return text
+    .split("\n")
+    .map((line) => prefix + line)
+    .join("\n");
+}

--- a/src/store/repository.ts
+++ b/src/store/repository.ts
@@ -147,6 +147,22 @@ export class Repository {
       .all(eventId) as AgentResultRow[];
     return rows.map(toAgentResult);
   }
+
+  getAgentResultById(resultId: string): AgentResult | null {
+    const row = this.db
+      .prepare(`SELECT * FROM agent_results WHERE result_id = ?`)
+      .get(resultId) as AgentResultRow | undefined;
+    return row ? toAgentResult(row) : null;
+  }
+
+  getRecentAgentResults(policyName?: string, limit: number = 20): AgentResult[] {
+    const query = policyName
+      ? `SELECT * FROM agent_results WHERE policy_name = ? ORDER BY started_at DESC LIMIT ?`
+      : `SELECT * FROM agent_results ORDER BY started_at DESC LIMIT ?`;
+    const params = policyName ? [policyName, limit] : [limit];
+    const rows = this.db.prepare(query).all(...params) as AgentResultRow[];
+    return rows.map(toAgentResult);
+  }
 }
 
 // --- 行 → 型変換 ---


### PR DESCRIPTION
## Summary

- `evorch results` コマンドを追加。エージェント実行結果（`agent_results` テーブル）を CLI から確認できるようにした
- RESULT ID（ULID）を引数に渡すと1件の詳細表示（出力テキスト全文）に切り替わる
- ポリシー名フィルタ・件数指定・JSON出力にも対応

## 変更ファイル

- `src/cli/results.ts` — 新規コマンド実装
- `src/store/repository.ts` — `getAgentResultById()` / `getRecentAgentResults()` を追加
- `src/cli/index.ts` — `registerResults` を登録

## 使い方

```bash
# 一覧表示
evorch results

# ポリシー名でフィルタ
evorch results my-policy

# 1件詳細表示（出力テキスト全文）
evorch results 01JQVZ8K3MNKXYZ1234567890A

# JSON形式
evorch results --json
```

## Test plan

- [ ] 既存テスト 33件がすべて通過することを確認
- [ ] `evorch results` で一覧が表示されること
- [ ] `evorch results <RESULT_ID>` で詳細と出力テキスト全文が表示されること
- [ ] 存在しない RESULT ID を渡すとエラーメッセージが出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
