### PR TITLE
Add macOS notification agent plugin

### DIFF
--- a/src/plugins/agents/notify.ts
+++ b/src/plugins/agents/notify.ts
@@ -1,0 +1,110 @@
+import { execFile } from "node:child_process";
+import { ulid } from "ulid";
+import type { AgentPlugin } from "../protocol.js";
+import type { AgentResult, EvOrchEvent } from "../../core/types.js";
+
+/**
+ * macOS 通知エージェント
+ * osascript を使用して通知センターへ通知を送る
+ *
+ * config:
+ *   title:    通知のタイトル (デフォルト: "Evorch")
+ *   message:  通知本文 (デフォルト: "{{event_type}} from {{source}}")
+ *   subtitle: サブタイトル (省略可)
+ *   sound:    通知音 例: "default", "Basso" (省略可)
+ */
+export class NotifyAgent implements AgentPlugin {
+  async run(
+    config: Record<string, unknown>,
+    event: EvOrchEvent,
+  ): Promise<AgentResult> {
+    const title = this.expandTemplate(
+      (config.title as string) ?? "Evorch",
+      event,
+    );
+    const message = this.expandTemplate(
+      (config.message as string) ?? "{{event_type}} from {{source}}",
+      event,
+    );
+    const subtitle = config.subtitle
+      ? this.expandTemplate(config.subtitle as string, event)
+      : undefined;
+    const sound = config.sound as string | undefined;
+
+    const script = this.buildScript(title, message, subtitle, sound);
+    const startedAt = new Date().toISOString();
+    const startTime = Date.now();
+
+    return new Promise<AgentResult>((resolve) => {
+      execFile(
+        "osascript",
+        ["-e", script],
+        { timeout: 10000 },
+        (error, stdout, stderr) => {
+          const completedAt = new Date().toISOString();
+          const duration_ms = Date.now() - startTime;
+
+          if (error) {
+            resolve({
+              result_id: ulid(),
+              event_id: event.event_id,
+              policy_name: "",
+              agent_plugin: "notify",
+              status: "failure",
+              output: stderr || String(error),
+              duration_ms,
+              started_at: startedAt,
+              completed_at: completedAt,
+            });
+            return;
+          }
+
+          resolve({
+            result_id: ulid(),
+            event_id: event.event_id,
+            policy_name: "",
+            agent_plugin: "notify",
+            status: "success",
+            output: stdout,
+            duration_ms,
+            started_at: startedAt,
+            completed_at: completedAt,
+          });
+        },
+      );
+    });
+  }
+
+  private buildScript(
+    title: string,
+    message: string,
+    subtitle?: string,
+    sound?: string,
+  ): string {
+    const esc = (s: string) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+    let script = `display notification "${esc(message)}" with title "${esc(title)}"`;
+
+    if (subtitle) {
+      script += ` subtitle "${esc(subtitle)}"`;
+    }
+    if (sound) {
+      script += ` sound name "${esc(sound)}"`;
+    }
+
+    return script;
+  }
+
+  private expandTemplate(template: string, event: EvOrchEvent): string {
+    return template
+      .replace(/\{\{event_id\}\}/g, event.event_id)
+      .replace(/\{\{event_type\}\}/g, event.type)
+      .replace(/\{\{source\}\}/g, event.source)
+      .replace(/\{\{severity\}\}/g, event.severity)
+      .replace(/\{\{payload\}\}/g, JSON.stringify(event.payload, null, 2))
+      .replace(/\{\{payload\.(\w+)\}\}/g, (_, key) => {
+        const value = event.payload[key];
+        return typeof value === "string" ? value : JSON.stringify(value);
+      });
+  }
+}

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -4,6 +4,7 @@ import { ShellJudge } from "./judges/shell.js";
 import { ClaudeCodeAgent } from "./agents/claude-code.js";
 import { ShellAgent } from "./agents/shell.js";
 import { CodexAgent } from "./agents/codex.js";
+import { NotifyAgent } from "./agents/notify.js";
 
 const BUILTIN_JUDGES: Record<string, () => JudgePlugin> = {
   shell: () => new ShellJudge(),
@@ -13,6 +14,7 @@ const BUILTIN_AGENTS: Record<string, () => AgentPlugin> = {
   "claude-code": () => new ClaudeCodeAgent(),
   shell: () => new ShellAgent(),
   codex: () => new CodexAgent(),
+  notify: () => new NotifyAgent(),
 };
 
 export class PluginRuntime {

--- a/test/plugins/notify-agent.test.ts
+++ b/test/plugins/notify-agent.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { NotifyAgent } from "../../src/plugins/agents/notify.js";
+import type { EvOrchEvent } from "../../src/core/types.js";
+
+const agent = new NotifyAgent();
+
+const createEvent = (payload: Record<string, unknown>): EvOrchEvent => ({
+  event_id: "test-event-001",
+  source: "test-job",
+  type: "test_event",
+  severity: "high",
+  fingerprint: "test:001",
+  payload,
+  labels: {},
+  created_at: new Date().toISOString(),
+  run_id: "run-001",
+});
+
+describe("NotifyAgent", () => {
+  it("テンプレート変数 {{event_type}} を展開する", () => {
+    const event = createEvent({});
+    // @ts-expect-error - private method test
+    const result = agent.expandTemplate("Type: {{event_type}}", event);
+    expect(result).toBe("Type: test_event");
+  });
+
+  it("テンプレート変数 {{source}} を展開する", () => {
+    const event = createEvent({});
+    // @ts-expect-error - private method test
+    const result = agent.expandTemplate("Source: {{source}}", event);
+    expect(result).toBe("Source: test-job");
+  });
+
+  it("テンプレート変数 {{severity}} を展開する", () => {
+    const event = createEvent({});
+    // @ts-expect-error - private method test
+    const result = agent.expandTemplate("Severity: {{severity}}", event);
+    expect(result).toBe("Severity: high");
+  });
+
+  it("テンプレート変数 {{payload.key}} を展開する", () => {
+    const event = createEvent({ message: "hello world" });
+    // @ts-expect-error - private method test
+    const result = agent.expandTemplate("Msg: {{payload.message}}", event);
+    expect(result).toBe("Msg: hello world");
+  });
+
+  it("AppleScript のダブルクォートをエスケープする", () => {
+    const event = createEvent({});
+    // @ts-expect-error - private method test
+    const script = agent.buildScript('He said "hi"', "normal message");
+    expect(script).toContain('\\"hi\\"');
+  });
+
+  it("subtitle を含む AppleScript を生成する", () => {
+    const event = createEvent({});
+    // @ts-expect-error - private method test
+    const script = agent.buildScript("Title", "Message", "Sub");
+    expect(script).toContain('subtitle "Sub"');
+  });
+
+  it("sound を含む AppleScript を生成する", () => {
+    const event = createEvent({});
+    // @ts-expect-error - private method test
+    const script = agent.buildScript("Title", "Message", undefined, "Basso");
+    expect(script).toContain('sound name "Basso"');
+  });
+
+  it("osascript が存在しない環境では failure を返す", async () => {
+    // osascript が存在しない場合 (Linux CI 等) でも failure で返ること
+    const event = createEvent({});
+    const result = await agent.run(
+      { title: "Test", message: "Hello" },
+      event,
+    );
+
+    // macOS では success、それ以外では failure
+    expect(["success", "failure"]).toContain(result.status);
+    expect(result.agent_plugin).toBe("notify");
+  });
+});


### PR DESCRIPTION
## Summary

- `notify` エージェントプラグインを新規追加
- `osascript` を使用して macOS 通知センターへ通知を送信（外部依存なし）
- judge 発火時・agent 実行後など、任意のポリシーに組み込んで通知を受け取れる

## 使い方

```yaml
policies:
  - name: notify-on-alert
    match:
      type: ".*"
    agent:
      plugin: notify
      config:
        title: "Evorch アラート"
        message: "{{event_type}} が {{source}} で発生"
        subtitle: "severity: {{severity}}"
        sound: "default"
```

### テンプレート変数

| 変数 | 内容 |
|------|------|
| `{{event_type}}` | イベント種別 |
| `{{source}}` | 発生元ジョブ名 |
| `{{severity}}` | 重要度 |
| `{{event_id}}` | イベント ID |
| `{{payload}}` | ペイロード全体 (JSON) |
| `{{payload.key}}` | ペイロードの特定フィールド |

### config オプション

| キー | デフォルト | 説明 |
|------|-----------|------|
| `title` | `"Evorch"` | 通知タイトル |
| `message` | `"{{event_type}} from {{source}}"` | 通知本文 |
| `subtitle` | なし | サブタイトル |
| `sound` | なし | 通知音 (`"default"`, `"Basso"` 等) |

## Test plan

- [x] `test/plugins/notify-agent.test.ts` — テスト 8 件追加・全通過
- [x] 型チェック (`tsc --noEmit`) 通過
- [x] macOS 実機で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
