### PR TITLE
feat: stop コマンドを追加し PID ファイルによるプロセス管理を実装

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,10 +8,12 @@ import { registerHistory } from "./history.js";
 import { registerValidate } from "./validate.js";
 import { registerJob } from "./job.js";
 import { registerResults } from "./results.js";
+import { registerStop } from "./stop.js";
 
 export const DEFAULT_CONFIG_DIR = join(homedir(), ".config", "evorch");
 export const DEFAULT_CONFIG_PATH = join(DEFAULT_CONFIG_DIR, "config.yaml");
 export const DEFAULT_JOBS_DIR = join(DEFAULT_CONFIG_DIR, "jobs");
+export const DEFAULT_PID_PATH = join(DEFAULT_CONFIG_DIR, "evorch.pid");
 
 export function createCli(): Command {
   const program = new Command();
@@ -30,6 +32,7 @@ export function createCli(): Command {
   registerValidate(program);
   registerJob(program);
   registerResults(program);
+  registerStop(program);
 
   return program;
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,3 +1,4 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import type { Command } from "commander";
 import { loadConfig } from "../config/loader.js";
 import { openDatabase } from "../store/database.js";
@@ -7,6 +8,7 @@ import { Executor } from "../core/executor.js";
 import { EventBus } from "../core/event-bus.js";
 import { PluginRuntime } from "../plugins/runtime.js";
 import { createLogger } from "../logger.js";
+import { DEFAULT_CONFIG_DIR, DEFAULT_PID_PATH } from "./index.js";
 
 export function registerRun(program: Command): void {
   program
@@ -27,6 +29,27 @@ export function registerRun(program: Command): void {
         onTick: (jobName) => executor.execute(jobName),
       }, logger);
 
+      // 二重起動チェック
+      if (existsSync(DEFAULT_PID_PATH)) {
+        const existingPid = parseInt(readFileSync(DEFAULT_PID_PATH, "utf-8").trim(), 10);
+        let isRunning = false;
+        try {
+          process.kill(existingPid, 0);
+          isRunning = true;
+        } catch {
+          logger.warn({ pid: existingPid }, "stale な PID ファイルを上書きします");
+        }
+        if (isRunning) {
+          logger.error({ pid: existingPid }, "evorch は既に起動中です");
+          process.exit(1);
+        }
+      }
+
+      // PID ファイル作成
+      mkdirSync(DEFAULT_CONFIG_DIR, { recursive: true });
+      writeFileSync(DEFAULT_PID_PATH, String(process.pid), "utf-8");
+      logger.info({ pid: process.pid, pidFile: DEFAULT_PID_PATH }, "PID ファイルを作成しました");
+
       const jobCount = Object.keys(config.jobs).length;
       logger.info({ jobs: jobCount }, "Evorch デーモン起動");
       scheduler.start();
@@ -36,6 +59,7 @@ export function registerRun(program: Command): void {
         logger.info("シャットダウン中...");
         scheduler.stop();
         db.close();
+        try { unlinkSync(DEFAULT_PID_PATH); } catch { /* 既に削除されている場合は無視 */ }
         process.exit(0);
       };
       process.on("SIGINT", shutdown);

--- a/src/cli/stop.ts
+++ b/src/cli/stop.ts
@@ -1,0 +1,101 @@
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import type { Command } from "commander";
+import { DEFAULT_PID_PATH } from "./index.js";
+
+const FORCE_TIMEOUT_MS = 5000;
+const POLL_INTERVAL_MS = 500;
+
+export function readPidFile(pidPath: string): number | null {
+  if (!existsSync(pidPath)) return null;
+  const content = readFileSync(pidPath, "utf-8").trim();
+  const pid = parseInt(content, 10);
+  return isNaN(pid) ? null : pid;
+}
+
+export function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "EPERM") return true;
+    return false;
+  }
+}
+
+export function removePidFile(pidPath: string): void {
+  try {
+    unlinkSync(pidPath);
+  } catch {
+    // 既に削除されている場合は無視
+  }
+}
+
+export function registerStop(program: Command): void {
+  program
+    .command("stop")
+    .description("バックグラウンドで動作中の evorch run を停止")
+    .option("--force", "SIGTERM タイムアウト後に SIGKILL を送信")
+    .action((opts) => {
+      const pid = readPidFile(DEFAULT_PID_PATH);
+
+      if (pid === null) {
+        if (!existsSync(DEFAULT_PID_PATH)) {
+          console.log("evorch は起動していません");
+          process.exit(0);
+        }
+        console.error("PID ファイルが破損しています");
+        removePidFile(DEFAULT_PID_PATH);
+        process.exit(1);
+      }
+
+      // プロセス生存確認
+      let running: boolean;
+      try {
+        process.kill(pid, 0);
+        running = true;
+      } catch (err: unknown) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ESRCH") {
+          removePidFile(DEFAULT_PID_PATH);
+          console.log(`プロセスが見つかりません。stale な PID ファイルを削除しました (PID: ${pid})`);
+          process.exit(0);
+        }
+        if (code === "EPERM") {
+          console.error(`権限がありません。sudo を試してください (PID: ${pid})`);
+          process.exit(1);
+        }
+        running = false;
+      }
+
+      if (!running) {
+        removePidFile(DEFAULT_PID_PATH);
+        console.log("evorch は起動していません");
+        process.exit(0);
+      }
+
+      // SIGTERM 送信
+      process.kill(pid, "SIGTERM");
+      console.log(`停止シグナルを送信しました (PID: ${pid})`);
+
+      if (!opts.force) {
+        process.exit(0);
+      }
+
+      // --force: タイムアウト付きでポーリングして SIGKILL
+      const deadline = Date.now() + FORCE_TIMEOUT_MS;
+      const timer = setInterval(() => {
+        if (!isProcessRunning(pid)) {
+          clearInterval(timer);
+          console.log("evorch を停止しました");
+          process.exit(0);
+        }
+        if (Date.now() >= deadline) {
+          clearInterval(timer);
+          process.kill(pid, "SIGKILL");
+          removePidFile(DEFAULT_PID_PATH);
+          console.log(`タイムアウト: SIGKILL を送信しました (PID: ${pid})`);
+          process.exit(0);
+        }
+      }, POLL_INTERVAL_MS);
+    });
+}

--- a/test/stop.test.ts
+++ b/test/stop.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readPidFile, isProcessRunning, removePidFile } from "../src/cli/stop.js";
+
+const TEST_DIR = join(tmpdir(), "evorch-stop-test-" + Date.now());
+const TEST_PID_PATH = join(TEST_DIR, "evorch.pid");
+
+describe("stop コマンド ヘルパー関数", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe("readPidFile", () => {
+    it("PID ファイルが存在しない場合は null を返す", () => {
+      expect(readPidFile(TEST_PID_PATH)).toBeNull();
+    });
+
+    it("有効な PID ファイルから数値を返す", () => {
+      writeFileSync(TEST_PID_PATH, "12345", "utf-8");
+      expect(readPidFile(TEST_PID_PATH)).toBe(12345);
+    });
+
+    it("前後の空白を無視して数値を返す", () => {
+      writeFileSync(TEST_PID_PATH, "  12345\n", "utf-8");
+      expect(readPidFile(TEST_PID_PATH)).toBe(12345);
+    });
+
+    it("数値以外の内容の場合は null を返す", () => {
+      writeFileSync(TEST_PID_PATH, "not-a-number", "utf-8");
+      expect(readPidFile(TEST_PID_PATH)).toBeNull();
+    });
+
+    it("空ファイルの場合は null を返す", () => {
+      writeFileSync(TEST_PID_PATH, "", "utf-8");
+      expect(readPidFile(TEST_PID_PATH)).toBeNull();
+    });
+  });
+
+  describe("isProcessRunning", () => {
+    it("自プロセスは生存している", () => {
+      expect(isProcessRunning(process.pid)).toBe(true);
+    });
+
+    it("存在しない PID は false を返す", () => {
+      expect(isProcessRunning(999999999)).toBe(false);
+    });
+  });
+
+  describe("removePidFile", () => {
+    it("存在するファイルを削除する", () => {
+      writeFileSync(TEST_PID_PATH, "12345", "utf-8");
+      expect(existsSync(TEST_PID_PATH)).toBe(true);
+      removePidFile(TEST_PID_PATH);
+      expect(existsSync(TEST_PID_PATH)).toBe(false);
+    });
+
+    it("存在しないファイルを削除しても例外を投げない", () => {
+      expect(() => removePidFile(TEST_PID_PATH)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `evorch stop` コマンドを新規追加
- PID ファイル（`~/.config/evorch/evorch.pid`）を使ったプロセス管理を実装
- `evorch run` に二重起動チェックを追加

## 変更内容

### `evorch stop` コマンド

```bash
# グレースフルシャットダウン（SIGTERM）
evorch stop

# タイムアウト後に強制終了（SIGKILL）
evorch stop --force
```

### 動作フロー

| シナリオ | 動作 |
|---|---|
| 起動していない状態で `stop` | "evorch は起動していません" |
| `stop` 実行 | SIGTERM 送信 → PID ファイル自動削除 |
| `--force` でタイムアウト | 5 秒後に SIGKILL + PID ファイル削除 |
| 二重起動を試みる | "evorch は既に起動中です" でブロック |
| stale PID ファイルがある場合 | プロセス不在を検出してファイルを削除 |

## Test plan

- `npm run build` でビルド確認
- `npm test` で全テスト（56 tests）パス確認
- 手動動作確認済み（起動・停止・二重起動・stale PID の各ケース）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
