### PR TITLE
feat: ジョブ定義テンプレートライブラリの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "evorch": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp -r src/templates/*.yaml dist/templates/",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/src/cli/job.ts
+++ b/src/cli/job.ts
@@ -7,8 +7,12 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, resolve } from "node:path";
+import { basename, dirname, resolve } from "node:path";
 import { DEFAULT_CONFIG_DIR, DEFAULT_JOBS_DIR } from "./index.js";
+import {
+  getTemplate,
+  listTemplates,
+} from "../templates/index.js";
 
 export function registerJob(program: Command): void {
   const job = program
@@ -84,8 +88,55 @@ export function registerJob(program: Command): void {
   // 初期化コマンド（設定ディレクトリとデフォルト設定を作成）
   job
     .command("init")
-    .description("設定ディレクトリを初期化")
-    .action(() => {
+    .description("設定ディレクトリを初期化、またはテンプレートからジョブを作成")
+    .option("--list", "テンプレート一覧を表示")
+    .option("-t, --template <name>", "テンプレート名を指定してジョブを作成")
+    .option("-o, --output <path>", "出力先パス（テンプレート使用時）")
+    .action((options: { list?: boolean; template?: string; output?: string }) => {
+      // テンプレート一覧表示
+      if (options.list) {
+        console.log("利用可能なテンプレート:\n");
+        const templates = listTemplates();
+        for (const t of templates) {
+          console.log(`  ${t.name}`);
+          console.log(`    ${t.description}\n`);
+        }
+        return;
+      }
+
+      // テンプレートからジョブ作成
+      if (options.template) {
+        const template = getTemplate(options.template);
+        if (!template) {
+          console.error(`テンプレートが見つかりません: ${options.template}`);
+          console.error("利用可能なテンプレートを確認するには --list を使用してください");
+          process.exit(1);
+        }
+
+        // 出力先を決定
+        const outputPath = options.output
+          ? resolve(options.output)
+          : resolve(DEFAULT_JOBS_DIR, `${template.name}.yaml`);
+
+        // 出力ディレクトリを作成
+        const outputDir = dirname(outputPath);
+        if (!existsSync(outputDir)) {
+          mkdirSync(outputDir, { recursive: true });
+        }
+
+        // ファイル存在チェック
+        if (existsSync(outputPath)) {
+          console.error(`ファイルが既に存在します: ${outputPath}`);
+          process.exit(1);
+        }
+
+        writeFileSync(outputPath, template.content);
+        console.log(`テンプレートからジョブを作成しました: ${outputPath}`);
+        console.log(`テンプレート: ${template.name} (${template.description})`);
+        return;
+      }
+
+      // デフォルト: 設定ディレクトリの初期化
       if (!existsSync(DEFAULT_CONFIG_DIR)) {
         mkdirSync(DEFAULT_CONFIG_DIR, { recursive: true });
       }

--- a/src/templates/daily-report.yaml
+++ b/src/templates/daily-report.yaml
@@ -1,0 +1,18 @@
+# 日次レポートの自動生成
+# 指定時刻に日次レポートを生成する
+
+schedule: "0 18 * * 1-5"  # 平日 18:00
+timezone: "Asia/Tokyo"
+
+judge:
+  plugin: shell
+  config:
+    command: |
+      echo "daily_report_trigger"
+    timeout: 5
+
+event:
+  type: "daily_report"
+  severity: "low"
+
+# 重複防止なし（毎日実行）

--- a/src/templates/deploy-health-check.yaml
+++ b/src/templates/deploy-health-check.yaml
@@ -1,0 +1,20 @@
+# デプロイ後のヘルスチェックと通知
+# 指定したエンドポイントのヘルスを監視し、異常時に通知
+
+schedule: "*/5 * * * *"  # 5分ごと
+timezone: "Asia/Tokyo"
+
+judge:
+  plugin: shell
+  config:
+    command: |
+      curl -sf ${HEALTH_ENDPOINT:-http://localhost:8080/health} -o /dev/null && echo "healthy" || echo "unhealthy"
+    timeout: 10
+
+event:
+  type: "health_check_failed"
+  severity: "high"
+
+dedup:
+  fingerprint: "health-check:${HEALTH_ENDPOINT}"
+  suppress_for: "30m"

--- a/src/templates/error-monitor.yaml
+++ b/src/templates/error-monitor.yaml
@@ -1,0 +1,28 @@
+# ログのエラー監視とアラート
+# 指定したログファイルやサービスのエラーを監視
+
+schedule: "*/5 * * * *"  # 5分ごと
+timezone: "Asia/Tokyo"
+
+judge:
+  plugin: shell
+  config:
+    command: |
+      # 直近5分のエラーログを確認
+      if [ -f "${LOG_FILE:-/var/log/app.log}" ]; then
+        ERROR_COUNT=$(find "${LOG_FILE}" -mmin -5 -exec grep -c "ERROR\|Error\|error" {} \; 2>/dev/null || echo "0")
+        if [ "$ERROR_COUNT" -gt 0 ]; then
+          tail -n 50 "${LOG_FILE}" | grep -E "ERROR|Error|error" | tail -n 10
+        fi
+      else
+        echo "Log file not found: ${LOG_FILE:-/var/log/app.log}"
+      fi
+    timeout: 15
+
+event:
+  type: "error_detected"
+  severity: "high"
+
+dedup:
+  fingerprint: "error-monitor:${LOG_FILE:-/var/log/app.log}"
+  suppress_for: "15m"

--- a/src/templates/github-issues.yaml
+++ b/src/templates/github-issues.yaml
@@ -1,0 +1,24 @@
+# GitHub Issue の定期監視と AI 分析
+# 新規 Issue を定期的に確認し、Claude Code で優先度を分析する
+
+schedule: "0 9 * * 1-5"  # 平日 9:00
+timezone: "Asia/Tokyo"
+
+judge:
+  plugin: shell
+  config:
+    command: |
+      gh issue list \
+        --repo ${GITHUB_REPO} \
+        --state open \
+        --json number,title,labels,createdAt \
+        --limit 20
+    timeout: 30
+
+event:
+  type: "github_issues_found"
+  severity: "medium"
+
+dedup:
+  fingerprint: "github-issues:${GITHUB_REPO}"
+  suppress_for: "8h"

--- a/src/templates/github-pr-review.yaml
+++ b/src/templates/github-pr-review.yaml
@@ -1,0 +1,25 @@
+# PR 作成時の自動レビュー依頼
+# 新規 PR を監視し、Claude Code でコードレビューを行う
+
+schedule: "*/10 * * * *"  # 10分ごと
+timezone: "Asia/Tokyo"
+
+judge:
+  plugin: shell
+  config:
+    command: |
+      gh pr list \
+        --repo ${GITHUB_REPO} \
+        --state open \
+        --draft false \
+        --json number,title,author,createdAt \
+        --limit 10
+    timeout: 30
+
+event:
+  type: "github_pr_found"
+  severity: "medium"
+
+dedup:
+  fingerprint: "github-pr-review:${GITHUB_REPO}"
+  suppress_for: "1h"

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,0 +1,58 @@
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { readFileSync, readdirSync } from "node:fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export interface TemplateInfo {
+  name: string;
+  description: string;
+  content: string;
+}
+
+// テンプレートの説明定義
+const TEMPLATE_DESCRIPTIONS: Record<string, string> = {
+  "github-issues": "GitHub Issue の定期監視と AI 分析",
+  "github-pr-review": "PR 作成時の自動レビュー依頼",
+  "deploy-health-check": "デプロイ後のヘルスチェックと通知",
+  "daily-report": "日次レポートの自動生成",
+  "error-monitor": "ログのエラー監視とアラート",
+  "slack-digest": "Slack メッセージのダイジェスト生成",
+};
+
+/**
+ * テンプレート一覧を取得
+ */
+export function listTemplates(): TemplateInfo[] {
+  const templates: TemplateInfo[] = [];
+  const files = readdirSync(__dirname).filter(
+    (f) => f.endsWith(".yaml") || f.endsWith(".yml"),
+  );
+
+  for (const file of files) {
+    const name = file.replace(/\.(yaml|yml)$/, "");
+    const content = readFileSync(join(__dirname, file), "utf-8");
+    templates.push({
+      name,
+      description: TEMPLATE_DESCRIPTIONS[name] || name,
+      content,
+    });
+  }
+
+  return templates.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * テンプレート名の一覧を取得
+ */
+export function getTemplateNames(): string[] {
+  return listTemplates().map((t) => t.name);
+}
+
+/**
+ * 指定したテンプレートを取得
+ */
+export function getTemplate(name: string): TemplateInfo | null {
+  const templates = listTemplates();
+  return templates.find((t) => t.name === name) || null;
+}

--- a/src/templates/slack-digest.yaml
+++ b/src/templates/slack-digest.yaml
@@ -1,0 +1,22 @@
+# Slack メッセージのダイジェスト生成
+# 指定チャンネルのメッセージを定期収集し、ダイジェストを生成
+
+schedule: "0 12,18 * * 1-5"  # 平日 12:00, 18:00
+timezone: "Asia/Tokyo"
+
+judge:
+  plugin: shell
+  config:
+    command: |
+      # Slack API を使用してメッセージを取得
+      # SLACK_BOT_TOKEN と SLACK_CHANNEL_ID を環境変数で設定
+      curl -s -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+        "https://slack.com/api/conversations.history?channel=${SLACK_CHANNEL_ID}&limit=50" | \
+        jq -r '.messages[] | select(.ts > (now - 21600 | tostring)) | .text' 2>/dev/null || echo "No messages"
+    timeout: 30
+
+event:
+  type: "slack_digest"
+  severity: "low"
+
+# 重複防止なし（1日2回実行）

--- a/test/templates.test.ts
+++ b/test/templates.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { listTemplates, getTemplate, getTemplateNames } from "../src/templates/index.js";
+
+describe("テンプレート機能", () => {
+  it("テンプレート一覧を取得できる", () => {
+    const templates = listTemplates();
+
+    expect(templates.length).toBeGreaterThan(0);
+
+    // 必須フィールドの確認
+    for (const t of templates) {
+      expect(t.name).toBeDefined();
+      expect(t.description).toBeDefined();
+      expect(t.content).toBeDefined();
+    }
+  });
+
+  it("期待するテンプレートが全て存在する", () => {
+    const names = getTemplateNames();
+
+    expect(names).toContain("github-issues");
+    expect(names).toContain("github-pr-review");
+    expect(names).toContain("deploy-health-check");
+    expect(names).toContain("daily-report");
+    expect(names).toContain("error-monitor");
+    expect(names).toContain("slack-digest");
+  });
+
+  it("指定したテンプレートを取得できる", () => {
+    const template = getTemplate("github-issues");
+
+    expect(template).not.toBeNull();
+    expect(template?.name).toBe("github-issues");
+    expect(template?.description).toBe("GitHub Issue の定期監視と AI 分析");
+    expect(template?.content).toContain("schedule:");
+    expect(template?.content).toContain("judge:");
+  });
+
+  it("存在しないテンプレートはnullを返す", () => {
+    const template = getTemplate("non-existent-template");
+
+    expect(template).toBeNull();
+  });
+
+  it("テンプレート内容に必要なフィールドが含まれる", () => {
+    const templates = listTemplates();
+
+    for (const t of templates) {
+      // 全テンプレートに schedule と judge が含まれることを確認
+      expect(t.content).toContain("schedule:");
+      expect(t.content).toContain("judge:");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `evorch job init` コマンドにテンプレート機能を追加
- `--list` オプションでテンプレート一覧を表示
- `--template <name>` オプションで指定テンプレートからジョブを作成
- `--output <path>` オプションで出力先を指定

提供テンプレート:
- `github-issues`: GitHub Issue の定期監視と AI 分析
- `github-pr-review`: PR 作成時の自動レビュー依頼
- `deploy-health-check`: デプロイ後のヘルスチェックと通知
- `daily-report`: 日次レポートの自動生成
- `error-monitor`: ログのエラー監視とアラート
- `slack-digest`: Slack メッセージのダイジェスト生成

## 使用方法

```bash
# テンプレート一覧を表示
evorch job init --list

# テンプレートからジョブを作成（デフォルトの出力先）
evorch job init --template github-issues

# 出力先を指定して作成
evorch job init --template github-issues --output ./jobs/my-github-job.yaml
```

## Test plan

- [x] `npm run build` が成功すること
- [x] `npm test` が全て通ること（61テスト）
- [x] `evorch job init --list` でテンプレート一覧が表示されること
- [x] `evorch job init --template <name>` でジョブファイルが作成されること

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
