### PR TITLE
feat: Webhook / HTTP トリガーのサポート

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -6,15 +6,21 @@ import { Repository } from "../store/repository.js";
 import { Scheduler } from "../core/scheduler.js";
 import { Executor } from "../core/executor.js";
 import { EventBus } from "../core/event-bus.js";
+import { WebhookServer } from "../core/webhook-server.js";
 import { PluginRuntime } from "../plugins/runtime.js";
 import { createLogger } from "../logger.js";
 import { DEFAULT_CONFIG_DIR, DEFAULT_PID_PATH } from "./index.js";
+
+interface RunOptions {
+  webhookPort?: number;
+}
 
 export function registerRun(program: Command): void {
   program
     .command("run")
     .description("デーモンモードで全ジョブをスケジュール実行")
-    .action(async (_opts, cmd) => {
+    .option("--webhook-port <port>", "Webhook サーバーのポート番号", parseInt)
+    .action(async (opts: RunOptions, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       const config = loadConfig(globalOpts.config);
       const logger = createLogger(globalOpts.verbose ? "debug" : config.log.level);
@@ -28,6 +34,12 @@ export function registerRun(program: Command): void {
       const scheduler = new Scheduler(config, {
         onTick: (jobName) => executor.execute(jobName),
       }, logger);
+
+      // Webhook サーバー初期化
+      let webhookServer: WebhookServer | null = null;
+      if (opts.webhookPort) {
+        webhookServer = new WebhookServer(config, executor, logger);
+      }
 
       // 二重起動チェック
       if (existsSync(DEFAULT_PID_PATH)) {
@@ -54,10 +66,18 @@ export function registerRun(program: Command): void {
       logger.info({ jobs: jobCount }, "Evorch デーモン起動");
       scheduler.start();
 
+      // Webhook サーバー起動
+      if (webhookServer && opts.webhookPort) {
+        webhookServer.start(opts.webhookPort);
+      }
+
       // Graceful shutdown
       const shutdown = () => {
         logger.info("シャットダウン中...");
         scheduler.stop();
+        if (webhookServer) {
+          webhookServer.stop();
+        }
         db.close();
         try { unlinkSync(DEFAULT_PID_PATH); } catch { /* 既に削除されている場合は無視 */ }
         process.exit(0);

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -17,15 +17,18 @@ export function registerStatus(program: Command): void {
 
       const statuses = [];
       for (const [jobName, jobConfig] of Object.entries(config.jobs)) {
-        const cron = new Cron(jobConfig.schedule, {
-          timezone: jobConfig.timezone,
-        });
-        const nextRun = cron.nextRun();
+        let nextRun: Date | null = null;
+        if (jobConfig.schedule) {
+          const cron = new Cron(jobConfig.schedule, {
+            timezone: jobConfig.timezone,
+          });
+          nextRun = cron.nextRun();
+        }
         const lastRun = store.getLastRun(jobName);
 
         statuses.push({
           job: jobName,
-          schedule: jobConfig.schedule,
+          schedule: jobConfig.schedule || "webhook",
           next_run: nextRun?.toISOString() ?? "-",
           last_run: lastRun?.started_at ?? "-",
           last_status: lastRun?.status ?? "-",

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -20,11 +20,13 @@ export function registerValidate(program: Command): void {
 
         // cron式の検証
         for (const [name, job] of Object.entries(config.jobs)) {
-          try {
-            new Cron(job.schedule);
-          } catch (err) {
-            console.error(`✗ ジョブ "${name}" のcron式が不正です: ${job.schedule}`);
-            process.exit(1);
+          if (job.schedule) {
+            try {
+              new Cron(job.schedule);
+            } catch (err) {
+              console.error(`✗ ジョブ "${name}" のcron式が不正です: ${job.schedule}`);
+              process.exit(1);
+            }
           }
         }
 
@@ -32,7 +34,8 @@ export function registerValidate(program: Command): void {
         console.log(`✓ ジョブ数: ${jobNames.length}`);
         for (const name of jobNames) {
           const job = config.jobs[name];
-          console.log(`  - ${name} (${job.schedule}) judge:${job.judge.plugin}`);
+          const trigger = job.schedule || "webhook";
+          console.log(`  - ${name} (${trigger}) judge:${job.judge.plugin}`);
         }
         console.log(`✓ ポリシー数: ${config.policies.length}`);
         for (const p of config.policies) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -18,10 +18,26 @@ const EventTemplateSchema = z.object({
   labels: z.record(z.string()).default({}),
 });
 
+const WebhookTriggerSchema = z.object({
+  type: z.literal("webhook"),
+  path: z.string(),
+  secret: z.string().optional(),
+});
+
+const ScheduleTriggerSchema = z.object({
+  type: z.literal("schedule").optional(),
+});
+
+const TriggerSchema = z.discriminatedUnion("type", [
+  WebhookTriggerSchema,
+  ScheduleTriggerSchema,
+]);
+
 /** ジョブ定義スキーマ（個別YAMLファイル用） */
 export const JobSchema = z.object({
-  schedule: z.string(),
+  schedule: z.string().optional(),
   timezone: z.string().optional(),
+  trigger: TriggerSchema.optional(),
   judge: JudgeConfigSchema,
   event: EventTemplateSchema,
   dedup: DedupSchema.optional(),

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -17,6 +17,12 @@ export class Scheduler {
 
   start(): void {
     for (const [jobName, jobConfig] of Object.entries(this.config.jobs)) {
+      // webhook トリガーのジョブはスケジュールしない
+      if (!jobConfig.schedule) {
+        this.logger.info({ job: jobName }, "スケジュールなし（Webhook トリガー）");
+        continue;
+      }
+
       const cron = new Cron(
         jobConfig.schedule,
         { timezone: jobConfig.timezone, protect: true },

--- a/src/core/webhook-server.ts
+++ b/src/core/webhook-server.ts
@@ -1,0 +1,155 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { Logger } from "../logger.js";
+import type { Executor } from "./executor.js";
+import type { Config, JobConfig } from "../config/schema.js";
+import { createHmac } from "node:crypto";
+
+interface WebhookJob {
+  name: string;
+  path: string;
+  secret?: string;
+  jobConfig: JobConfig;
+}
+
+export class WebhookServer {
+  private server: ReturnType<typeof createServer> | null = null;
+  private webhookJobs: Map<string, WebhookJob> = new Map();
+
+  constructor(
+    private config: Config,
+    private executor: Executor,
+    private logger: Logger,
+  ) {
+    // Webhook トリガーを持つジョブを抽出
+    for (const [name, jobConfig] of Object.entries(config.jobs)) {
+      if (jobConfig.trigger?.type === "webhook") {
+        const webhookPath = jobConfig.trigger.path;
+        this.webhookJobs.set(webhookPath, {
+          name,
+          path: webhookPath,
+          secret: jobConfig.trigger.secret,
+          jobConfig,
+        });
+        logger.info({ job: name, path: webhookPath }, "Webhook トリガーを登録");
+      }
+    }
+  }
+
+  start(port: number): void {
+    this.server = createServer((req, res) => this.handleRequest(req, res));
+
+    this.server.listen(port, () => {
+      this.logger.info({ port }, "Webhook サーバーを起動");
+    });
+
+    this.server.on("error", (err) => {
+      this.logger.error({ err }, "Webhook サーバーエラー");
+    });
+  }
+
+  stop(): void {
+    if (this.server) {
+      this.server.close();
+      this.logger.info("Webhook サーバーを停止");
+    }
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = req.url || "/";
+    const method = req.method || "GET";
+
+    // ヘルスチェックエンドポイント
+    if (url === "/health" || url === "/") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ok", timestamp: new Date().toISOString() }));
+      return;
+    }
+
+    // Webhook パスを検索
+    const webhookJob = this.webhookJobs.get(url);
+    if (!webhookJob) {
+      this.logger.warn({ path: url }, "未知の Webhook パス");
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+      return;
+    }
+
+    // POST メソッドのみ許可
+    if (method !== "POST") {
+      res.writeHead(405, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Method not allowed" }));
+      return;
+    }
+
+    try {
+      // リクエストボディを読み取り
+      const body = await this.readBody(req);
+
+      // シークレット検証
+      if (webhookJob.secret) {
+        const signature = req.headers["x-webhook-signature"] as string;
+        const expectedSignature = createHmac("sha256", webhookJob.secret)
+          .update(body)
+          .digest("hex");
+
+        if (!signature || signature !== expectedSignature) {
+          this.logger.warn({ job: webhookJob.name }, "Webhook シークレット検証失敗");
+          res.writeHead(401, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Invalid signature" }));
+          return;
+        }
+      }
+
+      // ジョブを実行（ペイロードを環境変数または judge に渡す）
+      this.logger.info({ job: webhookJob.name, path: url }, "Webhook トリガー受信");
+
+      // Webhook ペイロードを環境変数に設定
+      let parsedBody: unknown;
+      try {
+        parsedBody = JSON.parse(body);
+      } catch {
+        parsedBody = body;
+      }
+
+      // 元の環境変数を保存
+      const originalEnv = process.env.WEBHOOK_PAYLOAD;
+      process.env.WEBHOOK_PAYLOAD = body;
+
+      try {
+        await this.executor.execute(webhookJob.name);
+      } finally {
+        // 環境変数を復元
+        if (originalEnv !== undefined) {
+          process.env.WEBHOOK_PAYLOAD = originalEnv;
+        } else {
+          delete process.env.WEBHOOK_PAYLOAD;
+        }
+      }
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "triggered", job: webhookJob.name }));
+    } catch (err) {
+      this.logger.error({ err, path: url }, "Webhook 処理エラー");
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Internal server error" }));
+    }
+  }
+
+  private readBody(req: IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+      req.on("error", reject);
+    });
+  }
+
+  get registeredPaths(): string[] {
+    return Array.from(this.webhookJobs.keys());
+  }
+
+  /** Webhook ジョブ数 */
+  get jobCount(): number {
+    return this.webhookJobs.size;
+  }
+}

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { WebhookServer } from "../src/core/webhook-server.js";
+import type { Config, JobConfig } from "../src/config/schema.js";
+import type { Executor } from "../src/core/executor.js";
+import type { Logger } from "../src/logger.js";
+import { createServer } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+// モックロガー
+const mockLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+// モック Executor
+const mockExecutor = {
+  execute: async (_jobName: string) => {},
+} as unknown as Executor;
+
+describe("WebhookServer", () => {
+  const webhookJob: JobConfig = {
+    schedule: undefined,
+    trigger: {
+      type: "webhook",
+      path: "/trigger/test",
+      secret: "test-secret",
+    },
+    judge: {
+      plugin: "shell",
+      config: { command: "echo test" },
+    },
+    event: {
+      type: "test_event",
+      severity: "medium",
+      labels: {},
+    },
+  };
+
+  const config: Config = {
+    store: { path: "test.db" },
+    log: { level: "info" },
+    jobs_dir: "./jobs",
+    jobs: {
+      "webhook-job": webhookJob,
+    },
+    policies: [],
+    execution: {
+      max_concurrent: 3,
+      default_timeout: 120,
+      retry: {
+        max_attempts: 2,
+        backoff: "exponential",
+        initial_delay: 10,
+      },
+    },
+  };
+
+  it("Webhook トリガーを持つジョブを登録する", () => {
+    const server = new WebhookServer(config, mockExecutor, mockLogger);
+    expect(server.registeredPaths).toContain("/trigger/test");
+  });
+
+  it("スケジュールのみのジョブは登録しない", () => {
+    const scheduleConfig: Config = {
+      ...config,
+      jobs: {
+        "schedule-job": {
+          schedule: "0 9 * * *",
+          judge: { plugin: "shell", config: { command: "echo test" } },
+          event: { type: "test", severity: "medium", labels: {} },
+        },
+      },
+    };
+    const server = new WebhookServer(scheduleConfig, mockExecutor, mockLogger);
+    expect(server.registeredPaths).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- 外部システムから HTTP リクエストでジョブを起動できる Webhook トリガーを追加
- `evorch run --webhook-port <port>` で Webhook サーバーを起動
- HMAC シークレットによるリクエスト検証をサポート

## 設定例

```yaml
# jobs/deploy-check.yaml
trigger:
  type: webhook
  path: "/trigger/deploy-check"
  secret: "${WEBHOOK_SECRET}"

judge:
  plugin: shell
  config:
    command: "check-deploy.sh"
```

## 使用方法

```bash
# サーバー起動
evorch run --webhook-port 8080

# ヘルスチェック
curl http://localhost:8080/health

# Webhook トリガー
curl -X POST http://localhost:8080/trigger/deploy-check \
  -H "X-Webhook-Signature: $SIGNATURE" \
  -d '{"ref": "main"}'
```

## 機能

- POST リクエストでジョブを起動
- HMAC-SHA256 によるシークレット検証（オプション）
- ヘルスチェックエンドポイント `/health`
- ペイロードは `WEBHOOK_PAYLOAD` 環境変数で judge に渡される
- スケジュールジョブと Webhook ジョブを混在可能

## Test plan

- [x] `npm run build` が成功すること
- [x] `npm test` が全て通ること（58テスト）
- [x] Webhook トリガーを持つジョブが正しく登録されること
- [x] スケジュールのみのジョブは Webhook 登録されないこと

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
