### PR TITLE
feat: エラーハンドリングフローの追加

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -18,15 +18,6 @@ const EventTemplateSchema = z.object({
   labels: z.record(z.string()).default({}),
 });
 
-/** ジョブ定義スキーマ（個別YAMLファイル用） */
-export const JobSchema = z.object({
-  schedule: z.string(),
-  timezone: z.string().optional(),
-  judge: JudgeConfigSchema,
-  event: EventTemplateSchema,
-  dedup: DedupSchema.optional(),
-});
-
 const PolicyMatchSchema = z.object({
   type: z.string().optional(),
   severity: z
@@ -41,6 +32,21 @@ const PolicyMatchSchema = z.object({
 const AgentConfigSchema = z.object({
   plugin: z.string(),
   config: z.record(z.unknown()).default({}),
+});
+
+const OnFailureSchema = z.object({
+  agent: AgentConfigSchema.optional(),
+  command: z.string().optional(),
+});
+
+/** ジョブ定義スキーマ（個別YAMLファイル用） */
+export const JobSchema = z.object({
+  schedule: z.string(),
+  timezone: z.string().optional(),
+  judge: JudgeConfigSchema,
+  event: EventTemplateSchema,
+  dedup: DedupSchema.optional(),
+  on_failure: OnFailureSchema.optional(),
 });
 
 const PolicySchema = z.object({

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -107,6 +107,11 @@ export class Executor {
     } catch (err) {
       this.store.recordRunComplete(runId, "failed", undefined, undefined, String(err));
       this.logger.error({ job: jobName, run_id: runId, err }, "ジョブ実行失敗");
+
+      // on_failure ハンドラーを実行
+      if (jobConfig.on_failure) {
+        await this.runFailureHandler(jobConfig, jobName, runId, String(err));
+      }
     } finally {
       this.running.delete(runId);
       this.concurrentCount--;
@@ -124,6 +129,88 @@ export class Executor {
 
   get activeCount(): number {
     return this.concurrentCount;
+  }
+
+  /** エラーハンドラーを実行 */
+  private async runFailureHandler(
+    jobConfig: JobConfig,
+    jobName: string,
+    runId: string,
+    errorMessage: string,
+  ): Promise<void> {
+    const onFailure = jobConfig.on_failure;
+    if (!onFailure) return;
+
+    this.logger.info({ job: jobName, run_id: runId }, "エラーハンドラー実行開始");
+
+    try {
+      // テンプレート変数を展開
+      const context = {
+        job_name: jobName,
+        run_id: runId,
+        error: errorMessage,
+      };
+
+      if (onFailure.agent) {
+        // エージェントを実行
+        const config = this.expandTemplates(onFailure.agent.config, context);
+        await this.pluginRuntime.runAgent(onFailure.agent.plugin, config, {
+          event_id: `failure:${jobName}:${runId}`,
+          source: jobName,
+          type: "job_failure",
+          severity: "high",
+          fingerprint: `failure:${jobName}:${runId}`,
+          payload: { error: errorMessage, job_name: jobName, run_id: runId },
+          labels: {},
+          created_at: new Date().toISOString(),
+          run_id: runId,
+        });
+      }
+
+      if (onFailure.command) {
+        // シェルコマンドを実行
+        const expandedCommand = this.expandTemplateString(onFailure.command, context);
+        const { execFile } = await import("node:child_process");
+        await new Promise<void>((resolve, reject) => {
+          execFile("sh", ["-c", expandedCommand], { timeout: 60000 }, (err) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+      }
+
+      this.logger.info({ job: jobName, run_id: runId }, "エラーハンドラー完了");
+    } catch (handlerErr) {
+      this.logger.error(
+        { job: jobName, run_id: runId, err: handlerErr },
+        "エラーハンドラー実行失敗",
+      );
+    }
+  }
+
+  /** 設定オブジェクト内のテンプレートを展開 */
+  private expandTemplates(
+    config: Record<string, unknown>,
+    context: Record<string, string>,
+  ): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(config)) {
+      if (typeof value === "string") {
+        result[key] = this.expandTemplateString(value, context);
+      } else if (typeof value === "object" && value !== null) {
+        result[key] = this.expandTemplates(value as Record<string, unknown>, context);
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  /** 文字列内のテンプレート変数を展開 */
+  private expandTemplateString(template: string, context: Record<string, string>): string {
+    return template.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+      return context[key] ?? `{{${key}}}`;
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

- ジョブ実行でエラーが発生した場合に、別のエージェントやコマンドを実行するエラーハンドリングフローを追加
- `on_failure` フィールドをジョブ定義に追加
- テンプレート変数 `{{error}}`, `{{job_name}}`, `{{run_id}}` をサポート

## 設定例

```yaml
schedule: "*/5 * * * *"

judge:
  plugin: shell
  config:
    command: "check-deploy.sh"

on_failure:
  agent:
    plugin: shell
    config:
      command: "notify-slack.sh 'ジョブ失敗: {{job_name}} - {{error}}'"
```

## 機能

- `on_failure.agent`: エラー時にエージェントを実行
- `on_failure.command`: エラー時にシェルコマンドを実行
- テンプレート変数展開:
  - `{{error}}`: エラーメッセージ
  - `{{job_name}}`: ジョブ名
  - `{{run_id}}`: 実行ID
- エラーハンドラー自体のエラーもログに記録

## Test plan

- [x] `npm run build` が成功すること
- [x] `npm test` が全て通ること（56テスト）
- [x] `on_failure` スキーマが正しく定義されていること

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
