### PR TITLE
feat: ポリシーマッチングへの条件式サポートの追加

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -36,6 +36,7 @@ const PolicyMatchSchema = z.object({
     ])
     .optional(),
   labels: z.record(z.string()).optional(),
+  condition: z.string().optional(),
 });
 
 const AgentConfigSchema = z.object({

--- a/src/core/policy.ts
+++ b/src/core/policy.ts
@@ -27,5 +27,147 @@ export function matchEvent(event: EvOrchEvent, match: PolicyMatch): boolean {
     }
   }
 
+  // condition マッチ (条件式評価)
+  if (match.condition) {
+    if (!evaluateCondition(match.condition, event)) {
+      return false;
+    }
+  }
+
   return true;
+}
+
+/**
+ * 条件式を評価する
+ * サポート形式:
+ * - payload.field == value
+ * - payload.field > 10
+ * - payload.field && labels.field == 'value'
+ * - payload.field < 5 || payload.field > 10
+ */
+function evaluateCondition(condition: string, event: EvOrchEvent): boolean {
+  try {
+    // 安全性チェック: 危険なキーワードが含まれていないか確認
+    const dangerousPatterns = [
+      /\beval\b/,
+      /\bFunction\b/,
+      /\brequire\b/,
+      /\bimport\b/,
+      /\bprocess\b/,
+      /\bglobal\b/,
+      /\bwindow\b/,
+      /\bdocument\b/,
+      /\b__proto__\b/,
+      /\bconstructor\b/,
+    ];
+
+    for (const pattern of dangerousPatterns) {
+      if (pattern.test(condition)) {
+        console.warn(`安全でない条件式は評価されません: ${condition}`);
+        return false;
+      }
+    }
+
+    // トークン化して値を解決
+    const tokens = tokenize(condition);
+    const context = {
+      payload: event.payload,
+      labels: event.labels,
+    };
+
+    const resolvedTokens = tokens.map((token) => {
+      if (token.startsWith("payload.") || token.startsWith("labels.")) {
+        const value = getNestedValue(context, token);
+        return JSON.stringify(value);
+      }
+      return token;
+    });
+
+    const resolvedExpr = resolvedTokens.join(" ");
+
+    // JavaScript として評価
+    const jsExpr = resolvedExpr
+      .replace(/==/g, "===")
+      .replace(/!=/g, "!==")
+      .replace(/&&/g, " && ")
+      .replace(/\|\|/g, " || ");
+
+    return new Function(`return ${jsExpr}`)();
+  } catch (error) {
+    console.warn(`条件式の評価に失敗: ${condition}`, error);
+    return false;
+  }
+}
+
+/** 式をトークン化 */
+function tokenize(expr: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inString = false;
+  let stringChar = "";
+
+  for (let i = 0; i < expr.length; i++) {
+    const char = expr[i];
+
+    if (inString) {
+      current += char;
+      if (char === stringChar) {
+        tokens.push(current);
+        current = "";
+        inString = false;
+      }
+    } else if (char === '"' || char === "'") {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      current = char;
+      inString = true;
+      stringChar = char;
+    } else if (["=", "!", ">", "<", "&", "|"].includes(char)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      // 2文字演算子の処理
+      if (i + 1 < expr.length && ["=", "&", "|"].includes(expr[i + 1])) {
+        tokens.push(char + expr[i + 1]);
+        i++;
+      } else {
+        tokens.push(char);
+      }
+    } else if (char === " ") {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+/** ネストした値を取得 */
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split(".");
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (current === null || current === undefined) {
+      return undefined;
+    }
+    if (typeof current === "object") {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+
+  return current;
 }

--- a/test/event-bus.test.ts
+++ b/test/event-bus.test.ts
@@ -14,6 +14,17 @@ const baseEvent: EvOrchEvent = {
   run_id: "run-001",
 };
 
+const eventWithPayload: EvOrchEvent = {
+  ...baseEvent,
+  payload: {
+    error_count: 15,
+    message: "Deployment failed",
+    details: {
+      retry_count: 3,
+    },
+  },
+};
+
 describe("matchEvent", () => {
   it("type が一致する場合は true", () => {
     expect(matchEvent(baseEvent, { type: "threshold_exceeded" })).toBe(true);
@@ -59,5 +70,77 @@ describe("matchEvent", () => {
         labels: { env: "prod" },
       }),
     ).toBe(false);
+  });
+
+  describe("condition 条件式", () => {
+    it("payload フィールドの比較ができる", () => {
+      expect(
+        matchEvent(eventWithPayload, { condition: "payload.error_count > 10" }),
+      ).toBe(true);
+
+      expect(
+        matchEvent(eventWithPayload, { condition: "payload.error_count > 20" }),
+      ).toBe(false);
+    });
+
+    it("payload フィールドの等価比較ができる", () => {
+      expect(
+        matchEvent(eventWithPayload, { condition: "payload.message == 'Deployment failed'" }),
+      ).toBe(true);
+
+      expect(
+        matchEvent(eventWithPayload, { condition: "payload.message == 'Success'" }),
+      ).toBe(false);
+    });
+
+    it("ネストした payload フィールドにアクセスできる", () => {
+      expect(
+        matchEvent(eventWithPayload, { condition: "payload.details.retry_count == 3" }),
+      ).toBe(true);
+    });
+
+    it("labels との複合条件ができる", () => {
+      expect(
+        matchEvent(eventWithPayload, {
+          condition: "payload.error_count > 10 && labels.env == 'prod'",
+        }),
+      ).toBe(true);
+
+      expect(
+        matchEvent(eventWithPayload, {
+          condition: "payload.error_count > 10 && labels.env == 'staging'",
+        }),
+      ).toBe(false);
+    });
+
+    it("OR 条件ができる", () => {
+      expect(
+        matchEvent(eventWithPayload, {
+          condition: "payload.error_count < 5 || payload.error_count > 10",
+        }),
+      ).toBe(true);
+
+      expect(
+        matchEvent(eventWithPayload, {
+          condition: "payload.error_count < 5 || payload.error_count < 10",
+        }),
+      ).toBe(false);
+    });
+
+    it("type と condition の組み合わせ", () => {
+      expect(
+        matchEvent(eventWithPayload, {
+          type: "threshold_exceeded",
+          condition: "payload.error_count > 10",
+        }),
+      ).toBe(true);
+    });
+
+    it("安全でない条件式は評価されない", () => {
+      // eval や Function などの危険なコードは評価されない
+      expect(
+        matchEvent(eventWithPayload, { condition: "eval('1+1')" }),
+      ).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- ポリシーの `match` に `condition` フィールドを追加
- `payload.*` および `labels.*` を変数としてアクセス可能に
- 比較演算子 (==, !=, >, <, >=, <=) と論理演算子 (&&, ||) をサポート

## 設定例

```yaml
policies:
  # エラー件数 > 10 件の場合は緊急対応
  - name: critical-response
    match:
      type: "deploy_failed"
      condition: "payload.error_count > 10"
    agent:
      plugin: shell
      config:
        command: "trigger-incident.sh"

  # 通常のエラー通知
  - name: normal-notification
    match:
      type: "deploy_failed"
      condition: "payload.error_count <= 10"
    agent:
      plugin: slack
      config:
        channel: "#alerts"

  # labels との複合条件
  - name: team-specific
    match:
      type: "new_issues_found"
      condition: "payload.count > 0 && labels.team == 'platform'"
    agent:
      plugin: claude-code
```

## セキュリティ

危険なキーワード（eval, Function, require など）を含む条件式は評価されません。

## Test plan

- [x] `npm run build` が成功すること
- [x] `npm test` が全て通ること（63テスト）
- [x] payload フィールドの比較ができること
- [x] ネストしたフィールドにアクセスできること
- [x] AND/OR 条件ができること
- [x] 安全でない条件式がブロックされること

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
