### PR TITLE
feat: 多段フロー（ステップチェーン）のサポート

### DIFF
--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -32,7 +32,13 @@ export function registerValidate(program: Command): void {
         console.log(`✓ ジョブ数: ${jobNames.length}`);
         for (const name of jobNames) {
           const job = config.jobs[name];
-          console.log(`  - ${name} (${job.schedule}) judge:${job.judge.plugin}`);
+          if (job.steps) {
+            console.log(`  - ${name} (${job.schedule}) steps:${job.steps.length}`);
+          } else if (job.judge) {
+            console.log(`  - ${name} (${job.schedule}) judge:${job.judge.plugin}`);
+          } else {
+            console.log(`  - ${name} (${job.schedule}) [invalid]`);
+          }
         }
         console.log(`✓ ポリシー数: ${config.policies.length}`);
         for (const p of config.policies) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -18,14 +18,36 @@ const EventTemplateSchema = z.object({
   labels: z.record(z.string()).default({}),
 });
 
+const AgentConfigSchema = z.object({
+  plugin: z.string(),
+  config: z.record(z.unknown()).default({}),
+});
+
+/** ステップ定義スキーマ */
+const StepSchema = z.object({
+  name: z.string(),
+  judge: JudgeConfigSchema.optional(),
+  agent: AgentConfigSchema.optional(),
+  condition: z.string().optional(),
+});
+
 /** ジョブ定義スキーマ（個別YAMLファイル用） */
 export const JobSchema = z.object({
   schedule: z.string(),
   timezone: z.string().optional(),
-  judge: JudgeConfigSchema,
-  event: EventTemplateSchema,
+  // 従来の単一 judge/agent 形式（後方互換性）
+  judge: JudgeConfigSchema.optional(),
+  event: EventTemplateSchema.optional(),
   dedup: DedupSchema.optional(),
-});
+  // 新しいステップチェーン形式
+  steps: z.array(StepSchema).optional(),
+  output: EventTemplateSchema.optional(),
+}).refine(
+  (data) => (data.judge && data.event) || data.steps,
+  {
+    message: "judge + event または steps のいずれかが必要です",
+  }
+);
 
 const PolicyMatchSchema = z.object({
   type: z.string().optional(),
@@ -36,11 +58,6 @@ const PolicyMatchSchema = z.object({
     ])
     .optional(),
   labels: z.record(z.string()).optional(),
-});
-
-const AgentConfigSchema = z.object({
-  plugin: z.string(),
-  config: z.record(z.unknown()).default({}),
 });
 
 const PolicySchema = z.object({

--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -6,6 +6,11 @@ import type { PluginRuntime } from "../plugins/runtime.js";
 import type { EventBus } from "./event-bus.js";
 import type { Logger } from "../logger.js";
 
+interface StepOutput {
+  name: string;
+  output: Record<string, unknown>;
+}
+
 export class Executor {
   private running = new Map<string, AbortController>();
   private concurrentCount = 0;
@@ -49,61 +54,14 @@ export class Executor {
     this.logger.info({ job: jobName, run_id: runId }, "ジョブ実行開始");
 
     try {
-      // judge 実行
-      const judgeResult = await this.pluginRuntime.runJudge(
-        jobConfig.judge.plugin,
-        jobConfig.judge.config as Record<string, unknown>,
-        { jobName, runId },
-      );
-
-      this.logger.info(
-        { job: jobName, fired: judgeResult.fired, duration_ms: judgeResult.duration_ms },
-        "judge 完了",
-      );
-
-      if (!judgeResult.fired) {
-        this.store.recordRunComplete(runId, "completed", false, judgeResult.payload);
-        this.logger.info({ job: jobName }, "条件不成立 → スキップ");
-        return;
+      // ステップチェーン形式か従来形式かを判定
+      if (jobConfig.steps) {
+        await this.executeSteps(jobConfig, jobName, runId, options);
+      } else if (jobConfig.judge && jobConfig.event) {
+        await this.executeLegacy(jobConfig, jobName, runId, options);
+      } else {
+        throw new Error("ジョブ設定が不正です: judge + event または steps が必要です");
       }
-
-      // dedup チェック
-      if (jobConfig.dedup) {
-        const fingerprint = expandFingerprint(jobConfig.dedup.fingerprint);
-        if (this.store.checkFingerprint(fingerprint)) {
-          this.store.recordRunComplete(runId, "skipped", true, judgeResult.payload);
-          this.logger.info({ job: jobName, fingerprint }, "重複抑止によりスキップ");
-          return;
-        }
-
-        const expiresAt = calcExpiry(jobConfig.dedup.suppress_for);
-        this.store.recordFingerprint(fingerprint, expiresAt);
-      }
-
-      // dry-run の場合はイベント発行せずに終了
-      if (options?.dryRun) {
-        this.store.recordRunComplete(runId, "completed", true, judgeResult.payload);
-        this.logger.info({ job: jobName, payload: judgeResult.payload }, "[dry-run] イベント内容");
-        return;
-      }
-
-      // イベント生成 + 配送
-      const event: EvOrchEvent = {
-        event_id: `${jobConfig.event.type}:${jobName}:${now}`,
-        source: jobName,
-        type: jobConfig.event.type,
-        severity: jobConfig.event.severity,
-        fingerprint: jobConfig.dedup
-          ? expandFingerprint(jobConfig.dedup.fingerprint)
-          : `${jobName}:${now}`,
-        payload: judgeResult.payload,
-        labels: jobConfig.event.labels,
-        created_at: now,
-        run_id: runId,
-      };
-
-      await this.eventBus.emit(event);
-      this.store.recordRunComplete(runId, "completed", true, judgeResult.payload);
     } catch (err) {
       this.store.recordRunComplete(runId, "failed", undefined, undefined, String(err));
       this.logger.error({ job: jobName, run_id: runId, err }, "ジョブ実行失敗");
@@ -111,6 +69,252 @@ export class Executor {
       this.running.delete(runId);
       this.concurrentCount--;
     }
+  }
+
+  /** 従来の単一 judge/agent 形式 */
+  private async executeLegacy(
+    jobConfig: JobConfig,
+    jobName: string,
+    runId: string,
+    options?: { dryRun?: boolean },
+  ): Promise<void> {
+    const now = new Date().toISOString();
+
+    // judge 実行
+    const judgeResult = await this.pluginRuntime.runJudge(
+      jobConfig.judge!.plugin,
+      jobConfig.judge!.config as Record<string, unknown>,
+      { jobName, runId },
+    );
+
+    this.logger.info(
+      { job: jobName, fired: judgeResult.fired, duration_ms: judgeResult.duration_ms },
+      "judge 完了",
+    );
+
+    if (!judgeResult.fired) {
+      this.store.recordRunComplete(runId, "completed", false, judgeResult.payload);
+      this.logger.info({ job: jobName }, "条件不成立 → スキップ");
+      return;
+    }
+
+    // dedup チェック
+    if (jobConfig.dedup) {
+      const fingerprint = expandFingerprint(jobConfig.dedup.fingerprint);
+      if (this.store.checkFingerprint(fingerprint)) {
+        this.store.recordRunComplete(runId, "skipped", true, judgeResult.payload);
+        this.logger.info({ job: jobName, fingerprint }, "重複抑止によりスキップ");
+        return;
+      }
+
+      const expiresAt = calcExpiry(jobConfig.dedup.suppress_for);
+      this.store.recordFingerprint(fingerprint, expiresAt);
+    }
+
+    // dry-run の場合はイベント発行せずに終了
+    if (options?.dryRun) {
+      this.store.recordRunComplete(runId, "completed", true, judgeResult.payload);
+      this.logger.info({ job: jobName, payload: judgeResult.payload }, "[dry-run] イベント内容");
+      return;
+    }
+
+    // イベント生成 + 配送
+    const event: EvOrchEvent = {
+      event_id: `${jobConfig.event!.type}:${jobName}:${now}`,
+      source: jobName,
+      type: jobConfig.event!.type,
+      severity: jobConfig.event!.severity,
+      fingerprint: jobConfig.dedup
+        ? expandFingerprint(jobConfig.dedup.fingerprint)
+        : `${jobName}:${now}`,
+      payload: judgeResult.payload,
+      labels: jobConfig.event!.labels,
+      created_at: now,
+      run_id: runId,
+    };
+
+    await this.eventBus.emit(event);
+    this.store.recordRunComplete(runId, "completed", true, judgeResult.payload);
+  }
+
+  /** ステップチェーン形式 */
+  private async executeSteps(
+    jobConfig: JobConfig,
+    jobName: string,
+    runId: string,
+    options?: { dryRun?: boolean },
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    const stepOutputs: StepOutput[] = [];
+    let currentPayload: Record<string, unknown> = {};
+
+    for (const step of jobConfig.steps!) {
+      this.logger.info({ job: jobName, step: step.name }, "ステップ実行開始");
+
+      // 条件チェック
+      if (step.condition) {
+        const shouldRun = this.evaluateStepCondition(step.condition, stepOutputs, currentPayload);
+        if (!shouldRun) {
+          this.logger.info({ job: jobName, step: step.name }, "条件不成立 → ステップスキップ");
+          continue;
+        }
+      }
+
+      // judge ステップ
+      if (step.judge) {
+        const config = this.expandStepTemplates(step.judge.config, stepOutputs, currentPayload);
+        const result = await this.pluginRuntime.runJudge(
+          step.judge.plugin,
+          config as Record<string, unknown>,
+          { jobName, runId },
+        );
+
+        if (!result.fired) {
+          this.logger.info({ job: jobName, step: step.name }, "judge 条件不成立");
+          continue;
+        }
+
+        currentPayload = result.payload;
+        stepOutputs.push({ name: step.name, output: result.payload });
+      }
+
+      // agent ステップ
+      if (step.agent) {
+        const config = this.expandStepTemplates(step.agent.config, stepOutputs, currentPayload);
+        const result = await this.pluginRuntime.runAgent(
+          step.agent.plugin,
+          config as Record<string, unknown>,
+          {
+            event_id: `step:${step.name}:${runId}`,
+            source: jobName,
+            type: "step_execution",
+            severity: "medium",
+            fingerprint: `${step.name}:${runId}`,
+            payload: currentPayload,
+            labels: {},
+            created_at: now,
+            run_id: runId,
+          },
+        );
+
+        if (result.output) {
+          try {
+            currentPayload = JSON.parse(result.output);
+          } catch {
+            currentPayload = { raw: result.output };
+          }
+        }
+        stepOutputs.push({ name: step.name, output: currentPayload });
+      }
+
+      this.logger.info({ job: jobName, step: step.name }, "ステップ完了");
+    }
+
+    // dry-run の場合はイベント発行せずに終了
+    if (options?.dryRun) {
+      this.store.recordRunComplete(runId, "completed", true, currentPayload);
+      this.logger.info({ job: jobName, payload: currentPayload }, "[dry-run] ステップチェーン完了");
+      return;
+    }
+
+    // 最終出力をイベントとして発行
+    if (jobConfig.output) {
+      const event: EvOrchEvent = {
+        event_id: `${jobConfig.output.type}:${jobName}:${now}`,
+        source: jobName,
+        type: jobConfig.output.type,
+        severity: jobConfig.output.severity,
+        fingerprint: `${jobName}:${runId}`,
+        payload: currentPayload,
+        labels: jobConfig.output.labels,
+        created_at: now,
+        run_id: runId,
+      };
+
+      await this.eventBus.emit(event);
+    }
+
+    this.store.recordRunComplete(runId, "completed", true, currentPayload);
+  }
+
+  /** ステップ条件を評価 */
+  private evaluateStepCondition(
+    condition: string,
+    stepOutputs: StepOutput[],
+    currentPayload: Record<string, unknown>,
+  ): boolean {
+    try {
+      // steps.<name>.output 形式を解決
+      let resolvedCondition = condition;
+
+      for (const step of stepOutputs) {
+        const pattern = new RegExp(`steps\\.${step.name}\\.output`, "g");
+        resolvedCondition = resolvedCondition.replace(pattern, JSON.stringify(step.output));
+      }
+
+      // payload.* を解決
+      resolvedCondition = resolvedCondition.replace(/payload\.(\w+)/g, (_, key) => {
+        return JSON.stringify(currentPayload[key]);
+      });
+
+      // 安全性チェック
+      const dangerousPatterns = [/\beval\b/, /\bFunction\b/, /\brequire\b/];
+      for (const pattern of dangerousPatterns) {
+        if (pattern.test(resolvedCondition)) {
+          this.logger.warn(`安全でない条件式: ${condition}`);
+          return false;
+        }
+      }
+
+      return new Function(`return ${resolvedCondition}`)();
+    } catch (err) {
+      this.logger.warn({ condition, err }, "条件式の評価に失敗");
+      return false;
+    }
+  }
+
+  /** ステップテンプレートを展開 */
+  private expandStepTemplates(
+    config: Record<string, unknown>,
+    stepOutputs: StepOutput[],
+    currentPayload: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(config)) {
+      if (typeof value === "string") {
+        result[key] = this.expandStepTemplateString(value, stepOutputs, currentPayload);
+      } else if (typeof value === "object" && value !== null) {
+        result[key] = this.expandStepTemplates(value as Record<string, unknown>, stepOutputs, currentPayload);
+      } else {
+        result[key] = value;
+      }
+    }
+
+    return result;
+  }
+
+  /** 文字列内のステップテンプレートを展開 */
+  private expandStepTemplateString(
+    template: string,
+    stepOutputs: StepOutput[],
+    currentPayload: Record<string, unknown>,
+  ): string {
+    let result = template;
+
+    // steps.<name>.output を展開
+    for (const step of stepOutputs) {
+      const pattern = new RegExp(`\\{\\{\\s*steps\\.${step.name}\\.output\\s*\\}\\}`, "g");
+      result = result.replace(pattern, JSON.stringify(step.output));
+    }
+
+    // {{payload.*}} を展開
+    result = result.replace(/\{\{\s*payload\.(\w+)\s*\}\}/g, (_, key) => {
+      const value = currentPayload[key];
+      return typeof value === "string" ? value : JSON.stringify(value);
+    });
+
+    return result;
   }
 
   async cancel(runId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- ジョブ定義に `steps[]` を追加し、複数のステップを順次実行できる多段フローをサポート
- 各ステップで `judge` または `agent` を実行可能
- テンプレート変数 `{{steps.<name>.output}}` と `{{payload.*}}` をサポート
- 既存の単一 `judge`/`event` 設定との後方互換性を維持

## 設定例

```yaml
schedule: "0 * * * *"

steps:
  - name: check
    judge:
      plugin: shell
      config:
        command: "check-errors.sh"

  - name: analyze
    agent:
      plugin: claude-code
      config:
        prompt_template: "以下のエラーを分析: {{payload}}"

  - name: verify
    condition: "steps.analyze.output.needs_fix == true"
    agent:
      plugin: shell
      config:
        command: "apply-fix.sh"

output:
  type: "auto_fix_completed"
  severity: "medium"
```

## 機能

- **ステップチェーン**: 複数の judge/agent を順次実行
- **条件分岐**: `condition` で前ステップの結果に基づき実行可否を制御
- **テンプレート変数**:
  - `{{steps.<name>.output}}`: 前ステップの出力
  - `{{payload.*}}`: 現在のペイロード
- **後方互換性**: 従来の `judge` + `event` 形式も引き続きサポート

## Test plan

- [x] `npm run build` が成功すること
- [x] `npm test` が全て通ること（56テスト）
- [x] 従来の judge/event 形式が動作すること
- [x] steps 形式が動作すること

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
