### PR TITLE
feat: GitHub / Slack / HTTP Agent プラグインの追加

### DIFF
--- a/src/plugins/agents/github.ts
+++ b/src/plugins/agents/github.ts
@@ -1,0 +1,275 @@
+import { ulid } from "ulid";
+import type { AgentPlugin } from "../protocol.js";
+import type { AgentResult, EvOrchEvent } from "../../core/types.js";
+
+interface GitHubAgentConfig {
+  action: "create_issue" | "create_pr" | "add_comment" | "create_release";
+  repo: string;
+  token?: string;
+  // create_issue
+  title?: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+  // create_pr
+  head?: string;
+  base?: string;
+  // add_comment
+  issue_number?: number;
+  pull_number?: number;
+  comment?: string;
+  // create_release
+  tag_name?: string;
+  name?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+}
+
+/**
+ * GitHub Agent プラグイン
+ * GitHub REST API を使用して Issue/PR/Release などを操作
+ */
+export class GitHubAgent implements AgentPlugin {
+  async run(
+    config: Record<string, unknown>,
+    event: EvOrchEvent,
+  ): Promise<AgentResult> {
+    const githubConfig = this.parseConfig(config, event);
+    const token = githubConfig.token || process.env.GITHUB_TOKEN;
+
+    if (!token) {
+      return this.errorResult(event, "GITHUB_TOKEN が設定されていません");
+    }
+
+    const startedAt = new Date().toISOString();
+    const startTime = Date.now();
+
+    try {
+      let result: unknown;
+
+      switch (githubConfig.action) {
+        case "create_issue":
+          result = await this.createIssue(githubConfig, token);
+          break;
+        case "create_pr":
+          result = await this.createPullRequest(githubConfig, token);
+          break;
+        case "add_comment":
+          result = await this.addComment(githubConfig, token);
+          break;
+        case "create_release":
+          result = await this.createRelease(githubConfig, token);
+          break;
+        default:
+          throw new Error(`不明なアクション: ${githubConfig.action}`);
+      }
+
+      const completedAt = new Date().toISOString();
+      const duration_ms = Date.now() - startTime;
+
+      return {
+        result_id: ulid(),
+        event_id: event.event_id,
+        policy_name: "",
+        agent_plugin: "github",
+        status: "success",
+        output: JSON.stringify(result),
+        duration_ms,
+        started_at: startedAt,
+        completed_at: completedAt,
+      };
+    } catch (error) {
+      const completedAt = new Date().toISOString();
+      const duration_ms = Date.now() - startTime;
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      return {
+        result_id: ulid(),
+        event_id: event.event_id,
+        policy_name: "",
+        agent_plugin: "github",
+        status: "failure",
+        output: `GitHub API エラー: ${errorMessage}`,
+        duration_ms,
+        started_at: startedAt,
+        completed_at: completedAt,
+      };
+    }
+  }
+
+  private parseConfig(
+    config: Record<string, unknown>,
+    event: EvOrchEvent
+  ): GitHubAgentConfig {
+    return {
+      action: config.action as GitHubAgentConfig["action"],
+      repo: this.expandTemplate(config.repo as string, event),
+      token: config.token as string | undefined,
+      title: config.title ? this.expandTemplate(config.title as string, event) : undefined,
+      body: config.body ? this.expandTemplate(config.body as string, event) : undefined,
+      labels: config.labels as string[],
+      assignees: config.assignees as string[],
+      head: config.head as string,
+      base: config.base as string,
+      issue_number: config.issue_number as number,
+      pull_number: config.pull_number as number,
+      comment: config.comment ? this.expandTemplate(config.comment as string, event) : undefined,
+      tag_name: config.tag_name as string,
+      name: config.name ? this.expandTemplate(config.name as string, event) : undefined,
+      draft: config.draft as boolean,
+      prerelease: config.prerelease as boolean,
+    };
+  }
+
+  private async createIssue(
+    config: GitHubAgentConfig,
+    token: string
+  ): Promise<unknown> {
+    const response = await fetch(
+      `https://api.github.com/repos/${config.repo}/issues`,
+      {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "Accept": "application/vnd.github+json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: config.title,
+          body: config.body,
+          labels: config.labels,
+          assignees: config.assignees,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`GitHub API エラー (${response.status}): ${text}`);
+    }
+
+    return await response.json();
+  }
+
+  private async createPullRequest(
+    config: GitHubAgentConfig,
+    token: string
+  ): Promise<unknown> {
+    const response = await fetch(
+      `https://api.github.com/repos/${config.repo}/pulls`,
+      {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "Accept": "application/vnd.github+json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: config.title,
+          body: config.body,
+          head: config.head,
+          base: config.base,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`GitHub API エラー (${response.status}): ${text}`);
+    }
+
+    return await response.json();
+  }
+
+  private async addComment(
+    config: GitHubAgentConfig,
+    token: string
+  ): Promise<unknown> {
+    const issueNumber = config.issue_number || config.pull_number;
+    if (!issueNumber) {
+      throw new Error("issue_number または pull_number が必要です");
+    }
+
+    const response = await fetch(
+      `https://api.github.com/repos/${config.repo}/issues/${issueNumber}/comments`,
+      {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "Accept": "application/vnd.github+json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          body: config.comment,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`GitHub API エラー (${response.status}): ${text}`);
+    }
+
+    return await response.json();
+  }
+
+  private async createRelease(
+    config: GitHubAgentConfig,
+    token: string
+  ): Promise<unknown> {
+    const response = await fetch(
+      `https://api.github.com/repos/${config.repo}/releases`,
+      {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "Accept": "application/vnd.github+json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          tag_name: config.tag_name,
+          name: config.name,
+          body: config.body,
+          draft: config.draft ?? false,
+          prerelease: config.prerelease ?? false,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`GitHub API エラー (${response.status}): ${text}`);
+    }
+
+    return await response.json();
+  }
+
+  private expandTemplate(template: string, event: EvOrchEvent): string {
+    if (typeof template !== "string") return template;
+
+    return template
+      .replace(/\{\{event_id\}\}/g, event.event_id)
+      .replace(/\{\{event_type\}\}/g, event.type)
+      .replace(/\{\{source\}\}/g, event.source)
+      .replace(/\{\{payload\}\}/g, JSON.stringify(event.payload))
+      .replace(/\{\{payload\.(\w+)\}\}/g, (_, key) => {
+        const value = event.payload[key];
+        return typeof value === "string" ? value : JSON.stringify(value);
+      });
+  }
+
+  private errorResult(event: EvOrchEvent, error: string): AgentResult {
+    return {
+      result_id: ulid(),
+      event_id: event.event_id,
+      policy_name: "",
+      agent_plugin: "github",
+      status: "failure",
+      output: error,
+      duration_ms: 1,
+      started_at: new Date().toISOString(),
+      completed_at: new Date().toISOString(),
+    };
+  }
+}

--- a/src/plugins/agents/http.ts
+++ b/src/plugins/agents/http.ts
@@ -1,0 +1,125 @@
+import { ulid } from "ulid";
+import type { AgentPlugin } from "../protocol.js";
+import type { AgentResult, EvOrchEvent } from "../../core/types.js";
+
+interface HttpAgentConfig {
+  url: string;
+  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  headers?: Record<string, string>;
+  body?: string | Record<string, unknown>;
+  timeout?: number;
+}
+
+/**
+ * HTTP Agent プラグイン
+ * 汎用 HTTP リクエストを送信
+ */
+export class HttpAgent implements AgentPlugin {
+  async run(
+    config: Record<string, unknown>,
+    event: EvOrchEvent,
+  ): Promise<AgentResult> {
+    const httpConfig = this.parseConfig(config, event);
+    const startedAt = new Date().toISOString();
+    const startTime = Date.now();
+
+    try {
+      const controller = new AbortController();
+      const timeout = (httpConfig.timeout ?? 30) * 1000;
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+      const body =
+        httpConfig.body !== undefined
+          ? this.expandTemplate(
+              typeof httpConfig.body === "string"
+                ? httpConfig.body
+                : JSON.stringify(httpConfig.body),
+              event
+            )
+          : undefined;
+
+      const response = await fetch(httpConfig.url, {
+        method: httpConfig.method ?? "POST",
+        headers: httpConfig.headers,
+        body: body ? JSON.stringify(body) : undefined,
+        signal: controller.signal
+      });
+
+      clearTimeout(timeoutId);
+      const completedAt = new Date().toISOString();
+      const duration_ms = Date.now() - startTime;
+
+      if (!response.ok) {
+        const responseText = await response.text();
+        return {
+          result_id: ulid(),
+          event_id: event.event_id,
+          policy_name: "",
+          agent_plugin: "http",
+          status: "failure",
+          output: `HTTP ${response.status}: ${responseText}`,
+          duration_ms,
+          started_at: startedAt,
+          completed_at: completedAt,
+        };
+      }
+
+      const responseText = await response.text();
+      return {
+        result_id: ulid(),
+        event_id: event.event_id,
+        policy_name: "",
+        agent_plugin: "http",
+        status: "success",
+        output: responseText,
+        duration_ms,
+        started_at: startedAt,
+        completed_at: completedAt,
+      };
+    } catch (error) {
+      const completedAt = new Date().toISOString();
+      const duration_ms = Date.now() - startTime;
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      return {
+        result_id: ulid(),
+        event_id: event.event_id,
+        policy_name: "",
+        agent_plugin: "http",
+        status: "failure",
+        output: errorMessage,
+        duration_ms,
+        started_at: startedAt,
+        completed_at: completedAt,
+      };
+    }
+  }
+
+  private parseConfig(
+    config: Record<string, unknown>,
+    event: EvOrchEvent
+  ): HttpAgentConfig {
+    return {
+      url: this.expandTemplate(config.url as string, event),
+      method: config.method as HttpAgentConfig["method"],
+      headers: (config.headers as Record<string, string>) ?? {},
+      body: config.body as string | Record<string, unknown> | undefined,
+      timeout: config.timeout as number,
+    };
+  }
+
+  private expandTemplate(template: string, event: EvOrchEvent): string {
+    if (typeof template !== "string") return template;
+
+    return template
+      .replace(/\{\{event_id\}\}/g, event.event_id)
+      .replace(/\{\{event_type\}\}/g, event.type)
+      .replace(/\{\{source\}\}/g, event.source)
+      .replace(/\{\{payload\}\}/g, JSON.stringify(event.payload))
+      .replace(/\{\{payload\.(\w+)\}\}/g, (_, key) => {
+        const value = event.payload[key];
+        return typeof value === "string" ? value : JSON.stringify(value);
+      });
+  }
+}

--- a/src/plugins/agents/slack.ts
+++ b/src/plugins/agents/slack.ts
@@ -1,0 +1,148 @@
+import { ulid } from "ulid";
+import type { AgentPlugin } from "../protocol.js";
+import type { AgentResult, EvOrchEvent } from "../../core/types.js";
+
+interface SlackAgentConfig {
+  channel: string;
+  message: string;
+  token?: string;
+  thread_ts?: string;
+  blocks?: unknown[];
+  attachments?: unknown[];
+}
+
+/**
+ * Slack Agent プラグイン
+ * Slack Web API を使用してメッセージを送信
+ */
+export class SlackAgent implements AgentPlugin {
+  async run(
+    config: Record<string, unknown>,
+    event: EvOrchEvent,
+  ): Promise<AgentResult> {
+    const slackConfig = this.parseConfig(config, event);
+    const token = slackConfig.token || process.env.SLACK_BOT_TOKEN;
+
+    if (!token) {
+      return this.errorResult(event, "SLACK_BOT_TOKEN が設定されていません");
+    }
+
+    const startedAt = new Date().toISOString();
+    const startTime = Date.now();
+
+    try {
+      const body: Record<string, unknown> = {
+        channel: slackConfig.channel,
+        text: slackConfig.message,
+      };
+
+      if (slackConfig.thread_ts) {
+        body.thread_ts = slackConfig.thread_ts;
+      }
+      if (slackConfig.blocks) {
+        body.blocks = slackConfig.blocks;
+      }
+      if (slackConfig.attachments) {
+        body.attachments = slackConfig.attachments;
+      }
+
+      const response = await fetch("https://slack.com/api/chat.postMessage", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+
+      const completedAt = new Date().toISOString();
+      const duration_ms = Date.now() - startTime;
+      const result = await response.json();
+
+      if (!result.ok) {
+        return {
+          result_id: ulid(),
+          event_id: event.event_id,
+          policy_name: "",
+          agent_plugin: "slack",
+          status: "failure",
+          output: `Slack API エラー: ${result.error}`,
+          duration_ms,
+          started_at: startedAt,
+          completed_at: completedAt,
+        };
+      }
+
+      return {
+        result_id: ulid(),
+        event_id: event.event_id,
+        policy_name: "",
+        agent_plugin: "slack",
+        status: "success",
+        output: JSON.stringify(result),
+        duration_ms,
+        started_at: startedAt,
+        completed_at: completedAt,
+      };
+    } catch (error) {
+      const completedAt = new Date().toISOString();
+      const duration_ms = Date.now() - startTime;
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      return {
+        result_id: ulid(),
+        event_id: event.event_id,
+        policy_name: "",
+        agent_plugin: "slack",
+        status: "failure",
+        output: errorMessage,
+        duration_ms,
+        started_at: startedAt,
+        completed_at: completedAt,
+      };
+    }
+  }
+
+  private parseConfig(
+    config: Record<string, unknown>,
+    event: EvOrchEvent
+  ): SlackAgentConfig {
+    return {
+      channel: this.expandTemplate(config.channel as string, event),
+      message: this.expandTemplate(config.message as string, event),
+      token: config.token as string | undefined,
+      thread_ts: config.thread_ts as string | undefined,
+      blocks: config.blocks as unknown[],
+      attachments: config.attachments as unknown[],
+    };
+  }
+
+  private expandTemplate(template: string, event: EvOrchEvent): string {
+    if (typeof template !== "string") return template;
+
+    return template
+      .replace(/\{\{event_id\}\}/g, event.event_id)
+      .replace(/\{\{event_type\}\}/g, event.type)
+      .replace(/\{\{source\}\}/g, event.source)
+      .replace(/\{\{payload\}\}/g, JSON.stringify(event.payload))
+      .replace(/\{\{payload\.(\w+)\}\}/g, (_, key) => {
+        const value = event.payload[key];
+        return typeof value === "string" ? value : JSON.stringify(value);
+      });
+  }
+
+  private errorResult(event: EvOrchEvent, error: string): AgentResult {
+    return {
+      result_id: ulid(),
+      event_id: event.event_id,
+      policy_name: "",
+      agent_plugin: "slack",
+      status: "failure",
+      output: error,
+      duration_ms: 0,
+      started_at: new Date().toISOString(),
+      completed_at: new Date().toISOString(),
+    };
+  }
+}

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -5,6 +5,9 @@ import { ClaudeCodeAgent } from "./agents/claude-code.js";
 import { ShellAgent } from "./agents/shell.js";
 import { CodexAgent } from "./agents/codex.js";
 import { NotifyAgent } from "./agents/notify.js";
+import { GitHubAgent } from "./agents/github.js";
+import { SlackAgent } from "./agents/slack.js";
+import { HttpAgent } from "./agents/http.js";
 
 const BUILTIN_JUDGES: Record<string, () => JudgePlugin> = {
   shell: () => new ShellJudge(),
@@ -15,6 +18,9 @@ const BUILTIN_AGENTS: Record<string, () => AgentPlugin> = {
   shell: () => new ShellAgent(),
   codex: () => new CodexAgent(),
   notify: () => new NotifyAgent(),
+  github: () => new GitHubAgent(),
+  slack: () => new SlackAgent(),
+  http: () => new HttpAgent(),
 };
 
 export class PluginRuntime {


### PR DESCRIPTION
## Summary

- GitHub Agent プラグイン: Issue/PR/Release の作成、コメント追加
- Slack Agent プラグイン: メッセージ送信、Block Kit サポート
- HTTP Agent プラグイン: 汎用 REST API 呼び出し

## 設定例

### GitHub Issue 作成
```yaml
agent:
  plugin: github
  config:
    action: create_issue
    repo: "owner/repo"
    title: "自動検知: {{payload.title}}"
    body: "{{payload}}"
    labels: ["bug", "auto-detected"]
```

### Slack 通知
```yaml
agent:
  plugin: slack
  config:
    channel: "#alerts"
    message: "イベント発生: {{event_type}}\n詳細: {{payload}}"
```

### HTTP Webhook
```yaml
agent:
  plugin: http
  config:
    url: "https://api.example.com/webhook"
    method: POST
    headers:
      Authorization: "Bearer ${API_TOKEN}"
    body:
      event: "{{event_type}}"
      payload: "{{payload}}"
```

## Test plan

- [x] `npm run build` が成功すること
- [x] `npm test` が全て通ること（56テスト）
- [x] GitHub/Slack/HTTP エージェントが runtime に登録されていること

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
