### PR TITLE
feat: evorch run -d / --detach でバックグラウンド起動をサポート

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ export const DEFAULT_CONFIG_PATH = join(DEFAULT_CONFIG_DIR, "config.yaml");
 export const DEFAULT_JOBS_DIR = join(DEFAULT_CONFIG_DIR, "jobs");
 export const DEFAULT_POLICIES_DIR = join(DEFAULT_CONFIG_DIR, "policies");
 export const DEFAULT_PID_PATH = join(DEFAULT_CONFIG_DIR, "evorch.pid");
+export const DEFAULT_LOG_PATH = join(DEFAULT_CONFIG_DIR, "evorch.log");
 
 export function createCli(): Command {
   const program = new Command();

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { spawn } from "node:child_process";
 import type { Command } from "commander";
 import { loadConfig } from "../config/loader.js";
 import { openDatabase } from "../store/database.js";
@@ -8,16 +9,33 @@ import { Executor } from "../core/executor.js";
 import { EventBus } from "../core/event-bus.js";
 import { PluginRuntime } from "../plugins/runtime.js";
 import { createLogger } from "../logger.js";
-import { DEFAULT_CONFIG_DIR, DEFAULT_PID_PATH } from "./index.js";
+import { DEFAULT_CONFIG_DIR, DEFAULT_LOG_PATH, DEFAULT_PID_PATH } from "./index.js";
 
 export function registerRun(program: Command): void {
   program
     .command("run")
     .description("デーモンモードで全ジョブをスケジュール実行")
-    .action(async (_opts, cmd) => {
+    .option("-d, --detach", "バックグラウンド（デタッチモード）で起動")
+    .action(async (opts, cmd) => {
+      // detach フラグが立っている場合、自分自身を detached モードで再起動して終了
+      if (opts.detach) {
+        mkdirSync(DEFAULT_CONFIG_DIR, { recursive: true });
+        const args = process.argv.slice(2).filter(a => a !== "-d" && a !== "--detach");
+        const child = spawn(process.execPath, [process.argv[1], ...args], {
+          detached: true,
+          stdio: "ignore",
+          env: { ...process.env, EVORCH_LOG_FILE: DEFAULT_LOG_PATH },
+        });
+        child.unref();
+        console.log(`Evorch をバックグラウンドで起動しました (PID: ${child.pid})`);
+        console.log(`ログ: ${DEFAULT_LOG_PATH}`);
+        process.exit(0);
+      }
+
       const globalOpts = cmd.optsWithGlobals();
       const config = loadConfig(globalOpts.config);
-      const logger = createLogger(globalOpts.verbose ? "debug" : config.log.level);
+      const logFile = process.env.EVORCH_LOG_FILE;
+      const logger = createLogger(globalOpts.verbose ? "debug" : config.log.level, logFile);
 
       const db = openDatabase(config.store.path);
       const store = new Repository(db);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,9 @@
 import pino from "pino";
 
-export function createLogger(level: string = "info"): pino.Logger {
+export function createLogger(level: string = "info", logFile?: string): pino.Logger {
+  if (logFile) {
+    return pino({ level }, pino.destination(logFile));
+  }
   return pino({
     level,
     transport: {


### PR DESCRIPTION
## Summary

- `evorch run -d` / `--detach` オプションを追加
- `docker compose up -d` のようにバックグラウンドで起動できるようになった
- バックグラウンドプロセスのログは `~/.config/evorch/evorch.log` へ出力
- 停止は既存の `evorch stop` コマンドで可能

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/cli/index.ts` | `DEFAULT_LOG_PATH` 定数を追加 |
| `src/logger.ts` | `createLogger` に `logFile` オプションを追加（`pino.destination` でファイル出力） |
| `src/cli/run.ts` | `-d, --detach` オプションを追加、detach ロジックを実装 |

## 動作フロー

```
evorch run -d
  └─ spawn(node, [script, 'run'], { detached: true, stdio: 'ignore' })
       └─ EVORCH_LOG_FILE=~/.config/evorch/evorch.log を環境変数で渡す
  └─ child.unref() → 親プロセス終了
  
子プロセス (バックグラウンド)
  └─ PID ファイル作成、ファイルへログ出力、スケジューラ起動
```

## Test plan

- [x] `npm run build` が通る
- [x] `npm test` が全パス (83 tests)
- [x] `npx tsc --noEmit` が通る
- [x] `evorch run --help` に `-d, --detach` が表示される
- [x] `evorch run -d` でバックグラウンド起動し即座にプロンプトが返る
- [x] `~/.config/evorch/evorch.pid` に PID が書き込まれる
- [x] `~/.config/evorch/evorch.log` にログが出力される
- [x] `evorch stop` でプロセスが正常終了し PID ファイルが削除される

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
